### PR TITLE
fix CI

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -67,15 +67,18 @@ mock_layout = MagicMock()
 mock_layout.get_subjects.return_value = ['01']
 mock_layout.get_sessions.return_value = ['01']
 
+# Mock bids module
+mock_bids = MagicMock()
+mock_bids.BIDSLayout = MagicMock(return_value=mock_layout)
+
 # Configure the mocks
 sys.modules['ants'] = mock_ants
 sys.modules['numpy'] = np
 sys.modules['nibabel'] = MagicMock()
+sys.modules['bids'] = mock_bids
 
-# Patch BIDSLayout
-with patch('bids.BIDSLayout') as MockBIDSLayout:
-    MockBIDSLayout.return_value = mock_layout
-    from src.run import process_participant, process_session, main, nidm_conversion, get_bids_version, create_dataset_description
+# Import after mocking
+from src.run import process_participant, process_session, main, nidm_conversion, get_bids_version, create_dataset_description
 
 class TestRun(unittest.TestCase):
     """Test cases for the run module"""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,8 +7,15 @@ from unittest.mock import patch, MagicMock, PropertyMock
 import sys
 from pathlib import Path
 import json
-import pkg_resources
 import numpy as np
+
+# Handle pkg_resources import (deprecated in Python 3.12+)
+try:
+    import pkg_resources
+except ModuleNotFoundError:
+    # Create a mock pkg_resources for testing purposes
+    pkg_resources = MagicMock()
+    pkg_resources.DistributionNotFound = type('DistributionNotFound', (Exception,), {})
 
 # Add the project root to the Python path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -76,6 +83,7 @@ sys.modules['ants'] = mock_ants
 sys.modules['numpy'] = np
 sys.modules['nibabel'] = MagicMock()
 sys.modules['bids'] = mock_bids
+sys.modules['pkg_resources'] = pkg_resources
 
 # Import after mocking
 from src.run import process_participant, process_session, main, nidm_conversion, get_bids_version, create_dataset_description


### PR DESCRIPTION
This pull request updates the test setup in `tests/test_run.py` to improve compatibility with Python 3.12+ and strengthen the mocking of external dependencies. The main focus is handling the deprecation of `pkg_resources` and ensuring that `bids.BIDSLayout` is properly mocked for test reliability.

**Python compatibility and dependency mocking:**

* Added a try/except block to handle the import of `pkg_resources`, providing a mock implementation when the module is not available, which is necessary for Python 3.12+ compatibility.
* Introduced a mock for the `bids` module and its `BIDSLayout` class, and registered both `bids` and `pkg_resources` mocks in `sys.modules` to ensure that downstream imports use the mocked versions.