### PR TITLE
add skip-ants, fix participant-label, and other fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "src/ants_seg_to_nidm"]
 	path = src/ants_seg_to_nidm
-	url = https://github.com/yibeichan/ants_seg_to_nidm.git
-	branch = feature/link-ants-acquisition
+	url = https://github.com/ReproNim/ants_seg_to_nidm.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/ants_seg_to_nidm"]
 	path = src/ants_seg_to_nidm
-	url = https://github.com/ReproNim/ants_seg_to_nidm.git
+	url = https://github.com/yibeichan/ants_seg_to_nidm.git
+	branch = simple2

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ ants-bidsapp bids_dir output_dir participant --participant-label 01
 ### Advanced Options
 
 ```bash
+# Full pipeline with all options
 ants-bidsapp bids_dir output_dir participant \
   --participant-label 01 \
   --session-label pre \
@@ -90,28 +91,73 @@ ants-bidsapp bids_dir output_dir participant \
   --verbose
 ```
 
+### NIDM-Only Mode (Skip ANTs)
+
+If you have already run ANTs segmentation and only want to generate NIDM outputs:
+
+```bash
+# Run only NIDM conversion using existing ANTs results
+ants-bidsapp bids_dir output_dir participant \
+  --participant-label 01 \
+  --skip-ants \
+  --ants-input /path/to/existing/ants-seg \
+  --nidm-input /path/to/existing/nidm.ttl
+```
+
 ### Command-line Arguments
 
+**Required:**
 - `bids_dir`: Path to the BIDS dataset
 - `output_dir`: Path where outputs will be stored
-- `analysis_level`: Level of the analysis (participant)
-- `--participant-label`: Label(s) of the participant(s) to analyze
-- `--session-label`: Label(s) of the session(s) to analyze
+- `analysis_level`: Level of the analysis (`participant` or `session`)
+
+**Participant/Session Selection:**
+- `--participant-label`, `--participant_label`: Label of the participant to analyze (with or without "sub-" prefix)
+- `--session-label`, `--session_label`: Label of the session to analyze (with or without "ses-" prefix)
+
+**Processing Options:**
 - `--modality`: Imaging modality to process (default: T1w)
+- `--method`: Segmentation method - `quick` or `fusion` (default: fusion)
 - `--prob-threshold`: Probability threshold for binary mask creation (default: 0.5)
-- `--priors`: Paths to prior probability maps for segmentation
-- `--skip-nidm`: Skip NIDM conversion step
 - `--num-threads`: Number of threads to use for processing (default: 1)
-- `--verbose`: Print detailed logs
+
+**Skip Options:**
+- `--skip-nidm`: Skip NIDM conversion step (run ANTs only)
+- `--skip-ants`: Skip ANTs segmentation step (run NIDM only, requires `--ants-input`)
+- `--skip-bids-validation`: Skip BIDS validation step
+
+**Input Options (for NIDM-only mode):**
+- `--ants-input`: Path to existing ANTs segmentation derivatives (required if `--skip-ants`)
+- `--nidm-input`: Path to existing NIDM TTL file to update (optional)
+
+**Other:**
+- `-v`, `--verbose`: Print detailed logs
+- `--version`: Print version and exit
 
 ## Outputs
 
-The app generates the following outputs:
+The app generates the following output structure:
 
-- Segmentation results in BIDS-compatible format
-- Probability maps for each tissue class
-- Binary masks for each tissue class
-- NIDM-compatible outputs for reproducibility
+```
+output_dir/
+├── ants-seg/                                    # ANTs segmentation derivatives
+│   ├── dataset_description.json
+│   ├── anat/
+│   │   ├── sub-01_space-orig_dseg.nii.gz       # Segmentation labels
+│   │   └── sub-01_space-orig_label-*_probseg.nii.gz  # Probability maps
+│   └── stats/
+│       ├── antslabelstats.csv                   # Label statistics
+│       └── antsbrainvols.csv                    # Brain volume statistics
+├── nidm/                                        # NIDM outputs
+│   └── sub-01_nidm.json-ld                     # NIDM document (or nidm.ttl if updating existing)
+└── logs/                                        # Processing logs
+```
+
+Output files include:
+- **Segmentation results** in BIDS-derivatives format
+- **Probability maps** for each tissue class
+- **Statistics files** (CSV) for downstream analysis
+- **NIDM-compatible outputs** for reproducibility and data sharing
 
 ## NIDM Outputs
 

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -488,13 +488,11 @@ class ANTsSegmentation:
             Dictionary containing tissue and label volumes
         """
         # Set up directories
+        # Output directly to output_dir (no sub-* subfolder since BABS runs per-participant)
         session_part = f"_ses-{bids_session}" if bids_session else ""
-        bids_subject_dir = self.output_dir / f"sub-{bids_subject}"
-        if bids_session:
-            bids_subject_dir = bids_subject_dir / f"ses-{bids_session}"
-
-        anat_dir = bids_subject_dir / "anat"
-        stats_dir = bids_subject_dir / "stats"
+        
+        anat_dir = self.output_dir / "anat"
+        stats_dir = self.output_dir / "stats"
         anat_dir.mkdir(parents=True, exist_ok=True)
         stats_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -487,12 +487,17 @@ class ANTsSegmentation:
         dict
             Dictionary containing tissue and label volumes
         """
-        # Set up directories
-        # Output directly to output_dir (no sub-* subfolder since BABS runs per-participant)
+        # Set up directories with BIDS-compliant structure
+        # Create sub-*/ses-* subdirectories under output_dir
         session_part = f"_ses-{bids_session}" if bids_session else ""
-        
-        anat_dir = self.output_dir / "anat"
-        stats_dir = self.output_dir / "stats"
+
+        # Create subject/session directory structure
+        subject_dir = self.output_dir / f"sub-{bids_subject}"
+        if bids_session:
+            subject_dir = subject_dir / f"ses-{bids_session}"
+
+        anat_dir = subject_dir / "anat"
+        stats_dir = subject_dir / "stats"
         anat_dir.mkdir(parents=True, exist_ok=True)
         stats_dir.mkdir(parents=True, exist_ok=True)
 
@@ -526,8 +531,9 @@ class ANTsSegmentation:
 
         brain_volume = float(label_volumes_mm3.sum()) if label_volumes_mm3.size else 0.0
 
-        # Generate antslabelstats.csv
-        labelstats_file = stats_dir / "antslabelstats.csv"
+        # Generate antslabelstats.csv with subject prefix
+        seg_base = f"sub-{bids_subject}{session_part}"
+        labelstats_file = stats_dir / f"{seg_base}_antslabelstats.csv"
         label_df = pd.DataFrame({
             "Label": label_values.astype(int),
             "VolumeInVoxels": label_counts.astype(int),
@@ -552,7 +558,7 @@ class ANTsSegmentation:
             }
             brain_vol_data.update(tissue_volumes)
 
-        brainvols_file = stats_dir / "antsbrainvols.csv"
+        brainvols_file = stats_dir / f"{seg_base}_antsbrainvols.csv"
         pd.DataFrame([brain_vol_data]).to_csv(brainvols_file, index=False)
 
         # Save probability maps if available

--- a/src/run.py
+++ b/src/run.py
@@ -214,25 +214,28 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
                 existing_nidm_file = nidm_input_file
         
         # Define paths to segmentation outputs
-        # Files are directly under derivatives_dir (no sub-* folder since BABS runs per-participant)
-        # Handle session-specific paths consistently
-        anat_dir = derivatives_dir / "anat"
+        # Files are under sub-*/[ses-*/]anat/ and sub-*/[ses-*/]stats/ for BIDS compliance
         seg_base = f"sub-{bids_subject}"
         if bids_session:
             seg_base += f"_ses-{bids_session}"
-            
-        seg_path = anat_dir / f"{seg_base}_space-orig_dseg.nii.gz"
-        stats_dir = derivatives_dir / "stats"
-        
-        # Construct NIDM output filename
-        nidm_base = f"sub-{bids_subject}"
+
+        # Build subject/session directory path
+        subject_dir = derivatives_dir / f"sub-{bids_subject}"
         if bids_session:
-            nidm_base += f"_ses-{bids_session}"
-        nidm_file = nidm_dir / f"{nidm_base}_nidm.json-ld"
-            
-        # Define paths to the statistics files
-        label_stats = stats_dir / "antslabelstats.csv"
-        brain_vols = stats_dir / "antsbrainvols.csv"
+            subject_dir = subject_dir / f"ses-{bids_session}"
+
+        anat_dir = subject_dir / "anat"
+        stats_dir = subject_dir / "stats"
+
+        seg_path = anat_dir / f"{seg_base}_space-orig_dseg.nii.gz"
+
+        # Construct NIDM output filename (flat structure, TTL format)
+        nidm_base = seg_base
+        nidm_file = nidm_dir / f"{nidm_base}.ttl"
+
+        # Define paths to the statistics files (with subject prefix)
+        label_stats = stats_dir / f"{seg_base}_antslabelstats.csv"
+        brain_vols = stats_dir / f"{seg_base}_antsbrainvols.csv"
         
         # Check if required files exist
         required_files = [seg_path, label_stats, brain_vols]
@@ -242,7 +245,7 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
                 return False
         
         # If adding to existing NIDM file, output should be combined nidm.ttl
-        # Otherwise, output is subject-specific JSON-LD file
+        # Otherwise, output is subject-specific TTL file
         if existing_nidm_file:
             nidm_output = nidm_dir / "nidm.ttl"
         else:
@@ -262,6 +265,10 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
             "-subjid", f"sub-{bids_subject}",
             "-o", nidm_output_str
         ]
+
+        # Add session if available
+        if bids_session:
+            cmd.extend(["-session", f"ses-{bids_session}"])
 
         # Add JSON-LD flag if output format is JSON-LD
         if nidm_output_str.endswith('.json-ld'):

--- a/src/run.py
+++ b/src/run.py
@@ -73,8 +73,10 @@ def parse_arguments():
                         choices=['participant', 'session'])
     
     # Optional arguments
-    parser.add_argument('--participant-label', help='The label of the participant that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec.')
-    parser.add_argument('--session-label', help='The label of the session that should be analyzed. The label corresponds to ses-<session_label> from the BIDS spec.')
+    parser.add_argument('--participant-label', '--participant_label', dest='participant_label',
+                        help='The label of the participant that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (with or without "sub-" prefix).')
+    parser.add_argument('--session-label', '--session_label', dest='session_label',
+                        help='The label of the session that should be analyzed. The label corresponds to ses-<session_label> from the BIDS spec (with or without "ses-" prefix).')
     parser.add_argument('--modality', help='Modality to process [default: T1w]',
                         default='T1w')
     parser.add_argument('--prob-threshold', help='Probability threshold for binary mask creation [default: 0.5]',
@@ -89,6 +91,14 @@ def parse_arguments():
     parser.add_argument('--skip-nidm', help='Skip NIDM conversion step',
                         action='store_true')
     
+    # Skip ANTs and process existing results
+    parser.add_argument('--skip-ants', help='Skip ANTs segmentation and only run NIDM conversion. Requires --ants-input.',
+                        action='store_true')
+    parser.add_argument('--ants-input', help='Path to existing ANTs segmentation derivatives. Required if --skip-ants is set.',
+                        type=str, default=None)
+    parser.add_argument('--nidm-input', help='Path to existing NIDM TTL file to update (will be copied to output before updating).',
+                        type=str, default=None)
+    
     parser.add_argument('--num-threads', help='Number of threads to use for processing [default: 1]',
                         type=int, default=1)
     parser.add_argument('-v', '--verbose', help='Verbose output',
@@ -96,102 +106,126 @@ def parse_arguments():
     parser.add_argument('--version', action='version', 
                         version='ANTs BIDS App v0.1.0')
     
-    return parser.parse_args()
+    args = parser.parse_args()
+    
+    # Validate arguments
+    if args.skip_ants and not args.ants_input:
+        parser.error("--skip-ants requires --ants-input to specify existing ANTs derivatives")
+    
+    return args
 
 def initialize(args):
     """Initialize the ANTs BIDS app.
     Args:
         args: Command line arguments
     Returns:
-        tuple: (layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir, temp_dir)
+        tuple: (layout, segmenter, derivatives_dir, nidm_dir, nidm_input_file, temp_dir)
     """
     # Normalize incoming paths from argparse to Path objects
     args.bids_dir = Path(args.bids_dir)
     args.output_dir = Path(args.output_dir)
+    
     # Initialize BIDS Layout
     layout = BIDSLayout(str(args.bids_dir), validate=not args.skip_bids_validation)
     
-    nidm_input_dir = args.bids_dir.parent / "NIDM"
-    if nidm_input_dir.exists():
-        args.nidm_input_dir = nidm_input_dir
+    # Handle NIDM input file - prioritize command line argument over default location
+    nidm_input_file = None
+    if args.nidm_input:
+        nidm_input_file = Path(args.nidm_input)
+        if not nidm_input_file.exists():
+            raise FileNotFoundError(f"NIDM input file not found: {nidm_input_file}")
     else:
-        args.nidm_input_dir = None
+        # Legacy fallback: check default location in parent NIDM folder
+        legacy_nidm_dir = args.bids_dir.parent / "NIDM"
+        legacy_nidm_file = legacy_nidm_dir / "nidm.ttl"
+        if legacy_nidm_file.exists():
+            nidm_input_file = legacy_nidm_file
         
-    # Create output directories
-    output_dir = args.output_dir / 'ants_bidsapp'
-    output_dir.mkdir(parents=True, exist_ok=True)
+    # Create output directory directly (no ants_bidsapp wrapper)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
 
     # Create the output derivative directory with BIDS-compliant structure
-    derivatives_dir = output_dir / 'ants-seg'
+    # Outputs go directly to output_dir/ants-seg/ and output_dir/nidm/
+    derivatives_dir = args.output_dir / 'ants-seg'
     derivatives_dir.mkdir(parents=True, exist_ok=True)
     
     # Create dataset_description.json
     create_dataset_description(derivatives_dir, '0.1.0')
     
     # Create temporary directory
-    temp_dir = output_dir / 'tmp'
+    temp_dir = args.output_dir / 'tmp'
     temp_dir.mkdir(parents=True, exist_ok=True)
     
-    # Initialize segmentation with appropriate parameters
-    segmenter = ANTsSegmentation(
-        bids_dir=str(args.bids_dir),
-        output_dir=str(derivatives_dir),
-        temp_dir=str(temp_dir),
-        modality=args.modality,
-        prob_threshold=args.prob_threshold,
-        num_threads=args.num_threads,
-        verbose=args.verbose
-    )
+    # Initialize segmentation with appropriate parameters (only if not skipping ANTs)
+    segmenter = None
+    if not args.skip_ants:
+        segmenter = ANTsSegmentation(
+            bids_dir=str(args.bids_dir),
+            output_dir=str(derivatives_dir),
+            temp_dir=str(temp_dir),
+            modality=args.modality,
+            prob_threshold=args.prob_threshold,
+            num_threads=args.num_threads,
+            verbose=args.verbose
+        )
     
     # Create NIDM output directory
-    nidm_dir = output_dir / 'nidm'
+    nidm_dir = args.output_dir / 'nidm'
     nidm_dir.mkdir(parents=True, exist_ok=True)
     
-    return layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir, temp_dir
+    # If we have an input NIDM file, copy it to the output directory
+    if nidm_input_file:
+        output_nidm_file = nidm_dir / nidm_input_file.name
+        if not output_nidm_file.exists():
+            shutil.copy2(nidm_input_file, output_nidm_file)
+    
+    return layout, segmenter, derivatives_dir, nidm_dir, nidm_input_file, temp_dir
 
-def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_dir=None, bids_session=None, verbose=False, input_file=None):
+def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_file=None, bids_session=None, verbose=False, input_file=None):
     """Convert ANTs segmentation outputs to NIDM format.
     Args:
         logger: Logger instance
         derivatives_dir (str or Path): Path to ANTs derivatives directory
         nidm_dir (str or Path): Path to NIDM output directory
         bids_subject (str): Subject label (without "sub-" prefix)
-        nidm_input_dir (Path or None): Optional directory containing existing NIDM resources
+        nidm_input_file (Path or None): Optional existing NIDM TTL file to update
         bids_session (str): Session label (without "ses-" prefix)
         verbose (bool): Enable verbose output
         input_file (str or Path): Path to the input T1w file
     Returns:
         bool: True if conversion succeeded, False otherwise
     """
+    log_prefix = f"subject {bids_subject}" + (f", session {bids_session}" if bids_session else "")
+    
     try:
         # Convert paths to Path objects
         derivatives_dir = Path(derivatives_dir)
         nidm_dir = Path(nidm_dir)
         nidm_dir.mkdir(parents=True, exist_ok=True)
 
-        # Check if there's existing NIDM input data to incorporate
+        # Check for existing NIDM file in output directory (may have been copied from input)
         existing_nidm_file = None
-        if nidm_input_dir and nidm_input_dir.exists():
-            # Look for existing NIDM file (e.g., nidm.ttl)
-            nidm_ttl_file = nidm_input_dir / "nidm.ttl"
-            if nidm_ttl_file.exists():
-                existing_nidm_file = nidm_ttl_file
+        if nidm_input_file:
+            # The input file should have been copied to nidm_dir during initialize()
+            copied_nidm_file = nidm_dir / nidm_input_file.name
+            if copied_nidm_file.exists():
+                existing_nidm_file = copied_nidm_file
+            elif nidm_input_file.exists():
+                # Fallback to original if copy didn't happen
+                existing_nidm_file = nidm_input_file
         
         # Define paths to segmentation outputs
+        # Files are directly under derivatives_dir (no sub-* folder since BABS runs per-participant)
         if bids_session is None:
-            # Single session case
-            subject_dir = derivatives_dir / f"sub-{bids_subject}"
-            seg_path = subject_dir / "anat" / f"sub-{bids_subject}_space-orig_dseg.nii.gz"
-            stats_dir = subject_dir / "stats"
-            log_prefix = f"subject {bids_subject}"
-            nidm_file = nidm_dir / f"sub-{bids_subject}_space-orig_dseg.json-ld"
+            # Single session case - no sub-id subfolder
+            seg_path = derivatives_dir / "anat" / f"sub-{bids_subject}_space-orig_dseg.nii.gz"
+            stats_dir = derivatives_dir / "stats"
+            nidm_file = nidm_dir / f"sub-{bids_subject}_nidm.json-ld"
         else:
-            # Multi-session case
-            subject_dir = derivatives_dir / f"sub-{bids_subject}" / f"ses-{bids_session}"
-            seg_path = subject_dir / "anat" / f"sub-{bids_subject}_ses-{bids_session}_space-orig_dseg.nii.gz"
-            stats_dir = subject_dir / "stats"
-            log_prefix = f"subject {bids_subject}, session {bids_session}"
-            nidm_file = nidm_dir / f"sub-{bids_subject}_ses-{bids_session}_space-orig_dseg.json-ld"
+            # Multi-session case - no sub-id/ses-id subfolders
+            seg_path = derivatives_dir / "anat" / f"sub-{bids_subject}_ses-{bids_session}_space-orig_dseg.nii.gz"
+            stats_dir = derivatives_dir / "stats"
+            nidm_file = nidm_dir / f"sub-{bids_subject}_ses-{bids_session}_nidm.json-ld"
             
         # Define paths to the statistics files
         label_stats = stats_dir / "antslabelstats.csv"
@@ -212,22 +246,22 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
             nidm_output = nidm_file
         
         # Convert all paths to strings for subprocess call
-        label_stats = str(label_stats.absolute())
-        brain_vols = str(brain_vols.absolute())
-        seg_path = str(seg_path.absolute())
-        nidm_output = str(nidm_output.absolute())
+        label_stats_str = str(label_stats.absolute())
+        brain_vols_str = str(brain_vols.absolute())
+        seg_path_str = str(seg_path.absolute())
+        nidm_output_str = str(nidm_output.absolute())
         
         # Construct the command to run ants_seg_to_nidm.py
         cmd = [
             "python", "-m",
             "ants_seg_to_nidm.ants_seg_to_nidm",
-            "-f", f"{label_stats},{brain_vols},{seg_path}",
+            "-f", f"{label_stats_str},{brain_vols_str},{seg_path_str}",
             "-subjid", f"sub-{bids_subject}",
-            "-o", nidm_output
+            "-o", nidm_output_str
         ]
 
         # Add JSON-LD flag if output format is JSON-LD
-        if nidm_output.endswith('.json-ld'):
+        if nidm_output_str.endswith('.json-ld'):
             cmd.append("-j")
 
         logger.info(f"Converting segmentation to NIDM for {log_prefix}")
@@ -235,9 +269,9 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
         
         # Add existing NIDM file if available
         if existing_nidm_file:
-            cmd.extend(["--nidm", str(existing_nidm_file), "--forcenidm"])
+            cmd.extend(["--nidm", str(existing_nidm_file.absolute()), "--forcenidm"])
             logger.info(f"Adding data to existing NIDM file: {existing_nidm_file}")
-            logger.info(f"Combined NIDM will be written to: {nidm_output}")
+            logger.info(f"Combined NIDM will be written to: {nidm_output_str}")
 
         # Run the command from the script's directory
         result = subprocess.run(
@@ -264,48 +298,60 @@ def process_participant(args, logger):
     logger.info("Starting participant level analysis (single-session dataset)")
     
     # Initialize app
-    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir, temp_dir = initialize(args)
+    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_file, temp_dir = initialize(args)
     
     # Get subject to process
     available_subjects = layout.get_subjects()
     participant_label = args.participant_label
-    if not participant_label.startswith('sub-'):
-        participant_label = f"sub-{participant_label}"
+    # Normalize participant label - strip "sub-" if present for consistency
+    if participant_label.startswith('sub-'):
+        bids_subject = participant_label[4:]
+    else:
+        bids_subject = participant_label
+    participant_label = f"sub-{bids_subject}"  # Ensure full label for logging
     
-    bids_subject = participant_label[4:]  # Strip "sub-" for BIDS query
     if bids_subject not in available_subjects:
         logger.error(f"Subject {participant_label} not found in dataset")
         return 1
     
     # For participant level: process single session (no session folders expected)
-    session_label = None
     bids_session = None
     
     logger.info(f"Processing single-session data for subject {participant_label}")
     
-    # Process subject
-    if segmenter.run_subject(participant_label, session_label, method=args.method):
-        success = True
-        
-        # Convert segmentation to NIDM if requested
-        if not args.skip_nidm:
-            # Get input file path for NIDM conversion (single session)
-            input_path = layout.get(subject=bids_subject, suffix=args.modality, extension='nii.gz')
-            input_file = input_path[0].path if input_path else None
-            
-            success = nidm_conversion(
-                logger=logger,
-                derivatives_dir=derivatives_dir,
-                nidm_dir=nidm_dir,
-                bids_subject=bids_subject,
-                nidm_input_dir=nidm_input_dir,
-                bids_session=bids_session,
-                verbose=args.verbose,
-                input_file=input_file,
-            )
+    success = True
+    
+    # Run ANTs segmentation (unless skipped)
+    if args.skip_ants:
+        logger.info("Skipping ANTs segmentation (--skip-ants flag set)")
+        # Use existing ANTs derivatives if provided
+        if args.ants_input:
+            derivatives_dir = Path(args.ants_input)
+            logger.info(f"Using existing ANTs derivatives from: {derivatives_dir}")
     else:
-        success = False
-        logger.error(f"Segmentation failed for subject {participant_label}")
+        # Run segmentation
+        if segmenter.run_subject(participant_label, None, method=args.method):
+            logger.info(f"Segmentation completed for subject {participant_label}")
+        else:
+            success = False
+            logger.error(f"Segmentation failed for subject {participant_label}")
+    
+    # Convert segmentation to NIDM if requested and segmentation succeeded (or skipped)
+    if success and not args.skip_nidm:
+        # Get input file path for NIDM conversion (single session)
+        input_path = layout.get(subject=bids_subject, suffix=args.modality, extension='nii.gz')
+        input_file = input_path[0].path if input_path else None
+        
+        success = nidm_conversion(
+            logger=logger,
+            derivatives_dir=derivatives_dir,
+            nidm_dir=nidm_dir,
+            bids_subject=bids_subject,
+            nidm_input_file=nidm_input_file,
+            bids_session=bids_session,
+            verbose=args.verbose,
+            input_file=input_file,
+        )
     
     logger.info(f"Participant level analysis complete. Processing {'succeeded' if success else 'failed'}")
     
@@ -324,15 +370,18 @@ def process_session(args, logger):
     logger.info("Starting session level analysis (multi-session dataset)")
     
     # Initialize app
-    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir, temp_dir = initialize(args)
+    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_file, temp_dir = initialize(args)
     
     # Get subject to process
     available_subjects = layout.get_subjects()
     participant_label = args.participant_label
-    if not participant_label.startswith('sub-'):
-        participant_label = f"sub-{participant_label}"
+    # Normalize participant label - strip "sub-" if present for consistency
+    if participant_label.startswith('sub-'):
+        bids_subject = participant_label[4:]
+    else:
+        bids_subject = participant_label
+    participant_label = f"sub-{bids_subject}"  # Ensure full label for logging
     
-    bids_subject = participant_label[4:]  # Strip "sub-" for BIDS query
     if bids_subject not in available_subjects:
         logger.error(f"Subject {participant_label} not found in dataset")
         return 1
@@ -341,11 +390,14 @@ def process_session(args, logger):
     if not args.session_label:
         logger.error("--session-label is required for session level analysis")
         return 1
-        
+    
+    # Normalize session label
     session_label = args.session_label
-    if not session_label.startswith('ses-'):
-        session_label = f"ses-{session_label}"
-    bids_session = session_label[4:]  # Strip "ses-" for BIDS query
+    if session_label.startswith('ses-'):
+        bids_session = session_label[4:]
+    else:
+        bids_session = session_label
+    session_label = f"ses-{bids_session}"  # Ensure full label for logging
     
     # Validate session exists
     available_sessions = layout.get_sessions(subject=bids_subject)
@@ -355,29 +407,39 @@ def process_session(args, logger):
     
     logger.info(f"Processing session {session_label} for subject {participant_label}")
     
-    # Process this specific session
-    if segmenter.run_subject(participant_label, session_label, method=args.method):
-        success = True
-        
-        # Convert segmentation to NIDM if requested
-        if not args.skip_nidm:
-            # Get input file path for NIDM conversion
-            input_path = layout.get(subject=bids_subject, session=bids_session, suffix=args.modality, extension='nii.gz')
-            input_file = input_path[0].path if input_path else None
-            
-            success = nidm_conversion(
-                logger=logger,
-                derivatives_dir=derivatives_dir,
-                nidm_dir=nidm_dir,
-                bids_subject=bids_subject,
-                nidm_input_dir=nidm_input_dir,
-                bids_session=bids_session,
-                verbose=args.verbose,
-                input_file=input_file,
-            )
+    success = True
+    
+    # Run ANTs segmentation (unless skipped)
+    if args.skip_ants:
+        logger.info("Skipping ANTs segmentation (--skip-ants flag set)")
+        # Use existing ANTs derivatives if provided
+        if args.ants_input:
+            derivatives_dir = Path(args.ants_input)
+            logger.info(f"Using existing ANTs derivatives from: {derivatives_dir}")
     else:
-        success = False
-        logger.error(f"Segmentation failed for session {session_label}")
+        # Run segmentation
+        if segmenter.run_subject(participant_label, session_label, method=args.method):
+            logger.info(f"Segmentation completed for session {session_label}")
+        else:
+            success = False
+            logger.error(f"Segmentation failed for session {session_label}")
+    
+    # Convert segmentation to NIDM if requested and segmentation succeeded (or skipped)
+    if success and not args.skip_nidm:
+        # Get input file path for NIDM conversion
+        input_path = layout.get(subject=bids_subject, session=bids_session, suffix=args.modality, extension='nii.gz')
+        input_file = input_path[0].path if input_path else None
+        
+        success = nidm_conversion(
+            logger=logger,
+            derivatives_dir=derivatives_dir,
+            nidm_dir=nidm_dir,
+            bids_subject=bids_subject,
+            nidm_input_file=nidm_input_file,
+            bids_session=bids_session,
+            verbose=args.verbose,
+            input_file=input_file,
+        )
     
     logger.info(f"Session level analysis complete. Processing {'succeeded' if success else 'failed'}")
     

--- a/src/run.py
+++ b/src/run.py
@@ -141,21 +141,25 @@ def initialize(args):
         if legacy_nidm_file.exists():
             nidm_input_file = legacy_nidm_file
         
-    # Create output directory directly (no ants_bidsapp wrapper)
+    # Create output directory
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Create ants_bidsapp directory for all outputs
+    ants_bidsapp_dir = args.output_dir / 'ants_bidsapp'
+    ants_bidsapp_dir.mkdir(parents=True, exist_ok=True)
+
     # Create the output derivative directory with BIDS-compliant structure
-    # Outputs go directly to output_dir/ants-seg/ and output_dir/nidm/
-    derivatives_dir = args.output_dir / 'ants-seg'
+    # Outputs go to output_dir/ants_bidsapp/ants-seg/ and output_dir/ants_bidsapp/nidm/
+    derivatives_dir = ants_bidsapp_dir / 'ants-seg'
     derivatives_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Create dataset_description.json
     create_dataset_description(derivatives_dir, '0.1.0')
-    
-    # Create temporary directory
-    temp_dir = args.output_dir / 'tmp'
+
+    # Create temporary directory under ants_bidsapp
+    temp_dir = ants_bidsapp_dir / 'tmp'
     temp_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Initialize segmentation with appropriate parameters (only if not skipping ANTs)
     segmenter = None
     if not args.skip_ants:
@@ -168,9 +172,9 @@ def initialize(args):
             num_threads=args.num_threads,
             verbose=args.verbose
         )
-    
-    # Create NIDM output directory
-    nidm_dir = args.output_dir / 'nidm'
+
+    # Create NIDM output directory under ants_bidsapp
+    nidm_dir = ants_bidsapp_dir / 'nidm'
     nidm_dir.mkdir(parents=True, exist_ok=True)
     
     # If we have an input NIDM file, copy it to the output directory

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -127,16 +127,18 @@ class TestRun(unittest.TestCase):
     def create_derivatives_structure(self):
         """Create a minimal derivatives structure for testing NIDM conversion"""
         derivatives_dir = os.path.join(self.output_dir, "ants_bidsapp", "ants-seg")
-        anat_dir = os.path.join(derivatives_dir, "anat")
-        stats_dir = os.path.join(derivatives_dir, "stats")
-        
+        # Create BIDS-compliant sub-*/ses-* directory structure
+        subject_dir = os.path.join(derivatives_dir, "sub-01", "ses-01")
+        anat_dir = os.path.join(subject_dir, "anat")
+        stats_dir = os.path.join(subject_dir, "stats")
+
         os.makedirs(anat_dir, exist_ok=True)
         os.makedirs(stats_dir, exist_ok=True)
-        
-        # Create required files
+
+        # Create required files with subject/session prefix
         seg_file = os.path.join(anat_dir, "sub-01_ses-01_space-orig_dseg.nii.gz")
-        labelstats_file = os.path.join(stats_dir, "antslabelstats.csv")
-        brainvols_file = os.path.join(stats_dir, "antsbrainvols.csv")
+        labelstats_file = os.path.join(stats_dir, "sub-01_ses-01_antslabelstats.csv")
+        brainvols_file = os.path.join(stats_dir, "sub-01_ses-01_antsbrainvols.csv")
         
         # Write dummy content
         with open(seg_file, 'wb') as f:
@@ -189,7 +191,8 @@ class TestRun(unittest.TestCase):
             # Verify required arguments are present
             self.assertIn("-f", cmd_args)
             self.assertIn("-subjid", cmd_args)
-            self.assertIn("-j", cmd_args)
+            # TTL format is default, so -j flag should NOT be present
+            self.assertNotIn("-j", cmd_args)
             
             # Verify file paths exist
             paths_str = [arg for arg in cmd_args if ".csv" in arg or ".nii.gz" in arg][0]
@@ -289,23 +292,30 @@ class TestRun(unittest.TestCase):
             
             # Configure the run_subject method
             def mock_run_subject(subject_id, session_label=None, method='fusion'):
-                # Create output directories
-                subject_dir = os.path.join(self.output_dir, 'ants_bidsapp', 'ants-seg', subject_id)
+                # Create BIDS-compliant output directories with sub-*/[ses-*]/ structure
+                # subject_id comes in as "sub-01", extract the label
+                bids_subject = subject_id.replace('sub-', '') if subject_id.startswith('sub-') else subject_id
+                seg_base = f"sub-{bids_subject}"
+                subject_dir = os.path.join(self.output_dir, 'ants_bidsapp', 'ants-seg', f'sub-{bids_subject}')
+                if session_label:
+                    subject_dir = os.path.join(subject_dir, f'ses-{session_label}')
+                    seg_base += f"_ses-{session_label}"
+
                 anat_dir = os.path.join(subject_dir, 'anat')
                 stats_dir = os.path.join(subject_dir, 'stats')
                 os.makedirs(anat_dir, exist_ok=True)
                 os.makedirs(stats_dir, exist_ok=True)
-                
-                # Create dummy stats files
-                with open(os.path.join(stats_dir, 'antslabelstats.csv'), 'w') as f:
+
+                # Create dummy stats files with subject prefix
+                with open(os.path.join(stats_dir, f'{seg_base}_antslabelstats.csv'), 'w') as f:
                     f.write("Label,Volume\n1,1000.0\n2,2000.0\n")
-                with open(os.path.join(stats_dir, 'antsbrainvols.csv'), 'w') as f:
+                with open(os.path.join(stats_dir, f'{seg_base}_antsbrainvols.csv'), 'w') as f:
                     f.write("Name,Value\nBVOL,3000.0\n")
-                
+
                 # Create dummy segmentation file
-                with open(os.path.join(anat_dir, f"{subject_id}_space-orig_dseg.nii.gz"), 'w') as f:
+                with open(os.path.join(anat_dir, f"{seg_base}_space-orig_dseg.nii.gz"), 'w') as f:
                     f.write("dummy segmentation")
-                    
+
                 return True
             
             mock_instance.run_subject.side_effect = mock_run_subject
@@ -404,37 +414,42 @@ class TestRun(unittest.TestCase):
             
             # Configure the run_subject method
             def mock_run_subject(subject_id, session_label=None, method='fusion'):
-                # Create output directories
-                subject_dir = os.path.join(self.output_dir, 'ants_bidsapp', 'ants-seg', subject_id)
+                # Create BIDS-compliant output directories with sub-*/[ses-*]/ structure
+                # subject_id comes in as "sub-01", session_label as "ses-01"
+                bids_subject = subject_id.replace('sub-', '') if subject_id.startswith('sub-') else subject_id
+                seg_base = f"sub-{bids_subject}"
+                subject_dir = os.path.join(self.output_dir, 'ants_bidsapp', 'ants-seg', f'sub-{bids_subject}')
                 if session_label:
-                    subject_dir = os.path.join(subject_dir, session_label)
+                    bids_session = session_label.replace('ses-', '') if session_label.startswith('ses-') else session_label
+                    subject_dir = os.path.join(subject_dir, f'ses-{bids_session}')
+                    seg_base += f"_ses-{bids_session}"
+
                 anat_dir = os.path.join(subject_dir, 'anat')
                 stats_dir = os.path.join(subject_dir, 'stats')
                 os.makedirs(anat_dir, exist_ok=True)
                 os.makedirs(stats_dir, exist_ok=True)
-                
-                # Create dummy stats files
-                with open(os.path.join(stats_dir, 'antslabelstats.csv'), 'w') as f:
+
+                # Create dummy stats files with subject prefix
+                with open(os.path.join(stats_dir, f'{seg_base}_antslabelstats.csv'), 'w') as f:
                     f.write("Label,Volume\n1,1000.0\n2,2000.0\n")
-                with open(os.path.join(stats_dir, 'antsbrainvols.csv'), 'w') as f:
+                with open(os.path.join(stats_dir, f'{seg_base}_antsbrainvols.csv'), 'w') as f:
                     f.write("Name,Value\nBVOL,3000.0\n")
-                
+
                 # Create dummy segmentation file
-                seg_name = f"{subject_id}_ses-{session_label}_space-orig_dseg.nii.gz" if session_label else f"{subject_id}_space-orig_dseg.nii.gz"
-                with open(os.path.join(anat_dir, seg_name), 'w') as f:
+                with open(os.path.join(anat_dir, f"{seg_base}_space-orig_dseg.nii.gz"), 'w') as f:
                     f.write("dummy segmentation")
-                    
+
                 return True
-            
+
             mock_instance.run_subject.side_effect = mock_run_subject
             mock_instance.segment_image.return_value = segmentation_results
-            
+
             # Configure NIDM mock
             mock_nidm.return_value = True
-            
+
             # Run processing
             result = process_session(args, self.logger)
-            
+
             # Verify results
             self.assertEqual(result, 0)
             mock_instance.run_subject.assert_called_once_with("sub-01", "ses-01", method="quick")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -127,15 +127,14 @@ class TestRun(unittest.TestCase):
     def create_derivatives_structure(self):
         """Create a minimal derivatives structure for testing NIDM conversion"""
         derivatives_dir = os.path.join(self.output_dir, "ants_bidsapp", "ants-seg")
-        subject_dir = os.path.join(derivatives_dir, "sub-01")
-        anat_dir = os.path.join(subject_dir, "anat")
-        stats_dir = os.path.join(subject_dir, "stats")
+        anat_dir = os.path.join(derivatives_dir, "anat")
+        stats_dir = os.path.join(derivatives_dir, "stats")
         
         os.makedirs(anat_dir, exist_ok=True)
         os.makedirs(stats_dir, exist_ok=True)
         
         # Create required files
-        seg_file = os.path.join(anat_dir, "sub-01_space-orig_dseg.nii.gz")
+        seg_file = os.path.join(anat_dir, "sub-01_ses-01_space-orig_dseg.nii.gz")
         labelstats_file = os.path.join(stats_dir, "antslabelstats.csv")
         brainvols_file = os.path.join(stats_dir, "antsbrainvols.csv")
         
@@ -172,6 +171,7 @@ class TestRun(unittest.TestCase):
                 derivatives_dir,
                 nidm_dir,
                 "01",
+                bids_session="01",  # Pass session to match test file structure
                 verbose=True
             )
             
@@ -227,9 +227,11 @@ class TestRun(unittest.TestCase):
                 self.prob_threshold = 0.5
                 self.method = "quick"
                 self.skip_nidm = False
+                self.skip_ants = False
                 self.num_threads = 1
                 self.verbose = True
                 self.skip_bids_validation = True
+                self.nidm_input = None
         
         args = Args(self)
         
@@ -339,9 +341,11 @@ class TestRun(unittest.TestCase):
                 self.prob_threshold = 0.5
                 self.method = "quick"
                 self.skip_nidm = False
+                self.skip_ants = False
                 self.num_threads = 1
                 self.verbose = True
                 self.skip_bids_validation = True
+                self.nidm_input = None
         
         args = Args(self)
         

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -150,9 +150,9 @@ class TestANTsSegmentation(unittest.TestCase):
             self.assertTrue(anat_dir.exists())
             self.assertTrue(stats_dir.exists())
 
-            # Check stats files exist and have correct format
-            labelstats_file = stats_dir / "antslabelstats.csv"
-            brainvols_file = stats_dir / "antsbrainvols.csv"
+            # Check stats files exist and have correct format (with subject prefix)
+            labelstats_file = stats_dir / "sub-01_antslabelstats.csv"
+            brainvols_file = stats_dir / "sub-01_antsbrainvols.csv"
             
             self.assertTrue(labelstats_file.exists())
             self.assertTrue(brainvols_file.exists())
@@ -211,8 +211,9 @@ class TestANTsSegmentation(unittest.TestCase):
             seg_file = anat_dir / "sub-01_ses-01_space-orig_dseg.nii.gz"
             self.assertTrue(mock_write.call_args_list[0][0][1].endswith(str(seg_file)))
 
-            labelstats_file = stats_dir / "antslabelstats.csv"
-            brainvols_file = stats_dir / "antsbrainvols.csv"
+            # Check stats files with subject/session prefix
+            labelstats_file = stats_dir / "sub-01_ses-01_antslabelstats.csv"
+            brainvols_file = stats_dir / "sub-01_ses-01_antsbrainvols.csv"
 
             self.assertTrue(labelstats_file.exists())
             self.assertTrue(brainvols_file.exists())


### PR DESCRIPTION
This pull request introduces significant improvements to the ANTs BIDS App, focusing on enhanced flexibility for NIDM-only workflows, improved command-line argument handling, and more robust output organization. The changes enable users to skip ANTs segmentation and generate NIDM outputs from existing results, clarify and expand documentation, and update the codebase for clearer, more consistent directory structures and argument parsing.

**Major new features and improvements:**

*Support for NIDM-only workflows and enhanced argument parsing:*

- Added `--skip-ants`, `--ants-input`, and `--nidm-input` command-line options to allow users to skip ANTs segmentation and generate NIDM outputs from existing ANTs results. Argument validation ensures that required inputs are provided when skipping ANTs. [[1]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48R94-R231) [[2]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L267-R343)
- Improved handling of participant and session labels by supporting both dashed and underscored forms (e.g., `--participant-label` and `--participant_label`), and normalizing labels internally for consistency. [[1]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L76-R79) [[2]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L327-L335) [[3]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48R393-R399)

*Documentation and usability:*

- Expanded the `README.md` to document the new NIDM-only mode, provide clearer descriptions of all command-line arguments (grouped by theme), and illustrate the output directory structure in detail. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R160) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84)

*Output organization and directory structure:*

- Updated output organization so that ANTs derivatives and statistics are written directly under the output directory (not nested within per-subject/session folders), aligning with per-participant execution workflows such as BABS.
- Refined the initialization and output directory creation logic to ensure all outputs are placed in a consistent, BIDS-compliant structure, and to handle copying/updating of existing NIDM files robustly. [[1]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48R94-R231) [[2]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L267-R343)

*Submodule and dependency updates:*

- Updated the `ants_seg_to_nidm` submodule to point to the main `ReproNim` repository, and advanced to a newer commit. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L3-R3) [[2]](diffhunk://#diff-f1ae35be146fcb3fa1aa4d7a14c26afa3b699132d640a188dd83a91d0ec788f7L1-R1)

These changes collectively make the app more flexible for different workflows, improve user experience, and ensure outputs are organized in a clear and reproducible manner.