### PR TITLE
standardize naming and packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ENV TEMP=/work
 ENV TMP=/work
 
 # Create entrypoint script with proper permissions
-RUN echo '#!/bin/bash\nexec ants-nidm-bidsapp "$@"' > /entrypoint.sh && \
+RUN echo '#!/bin/bash\nexec ants-nidm "$@"' > /entrypoint.sh && \
     chmod 755 /entrypoint.sh
 
 # Ensure all installed binaries are executable

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ This BIDS App follows standard BIDS Apps practices with a Dockerfile as the prim
 python setup.py docker
 
 # Or directly with Docker
-docker build -t ants-nidm-bidsapp:latest .
+docker build -t ants-nidm_bidsapp:latest .
 
 # Save for transfer to HPC (if needed)
-docker save ants-nidm-bidsapp:latest -o ants-nidm-bidsapp.tar
+docker save ants-nidm_bidsapp:latest -o ants-nidm_bidsapp.tar
 ```
 
 #### Building with Singularity/Apptainer (for HPC environments)
@@ -52,7 +52,7 @@ docker save ants-nidm-bidsapp:latest -o ants-nidm-bidsapp.tar
 ```bash
 # Direct build from Singularity definition file
 # The --fakeroot flag is required on HPC systems without root access
-apptainer build --fakeroot ants-nidm-bidsapp.sif Singularity
+apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity
 
 # Or using the setup.py helper
 python setup.py singularity
@@ -64,10 +64,10 @@ If you have a Docker image (either built locally or from a tar file):
 
 ```bash
 # From a saved Docker tar file
-singularity build ants-nidm-bidsapp.sif docker-archive://ants-nidm-bidsapp.tar
+singularity build ants-nidm_bidsapp.sif docker-archive://ants-nidm_bidsapp.tar
 
 # From local Docker daemon (requires Docker)
-singularity build ants-nidm-bidsapp.sif docker-daemon://ants-nidm-bidsapp:latest
+singularity build ants-nidm_bidsapp.sif docker-daemon://ants-nidm_bidsapp:latest
 ```
 
 ## Usage
@@ -75,14 +75,14 @@ singularity build ants-nidm-bidsapp.sif docker-daemon://ants-nidm-bidsapp:latest
 ### Basic Usage
 
 ```bash
-ants-nidm-bidsapp bids_dir output_dir participant --participant-label 01
+ants-nidm bids_dir output_dir participant --participant-label 01
 ```
 
 ### Advanced Options
 
 ```bash
 # Full pipeline with all options
-ants-nidm-bidsapp bids_dir output_dir participant \
+ants-nidm bids_dir output_dir participant \
   --participant-label 01 \
   --session-label pre \
   --modality T1w \
@@ -98,7 +98,7 @@ If you have already run ANTs segmentation and only want to generate NIDM outputs
 
 ```bash
 # Run only NIDM conversion using existing ANTs results
-ants-nidm-bidsapp bids_dir output_dir participant \
+ants-nidm bids_dir output_dir participant \
   --participant-label 01 \
   --skip-ants \
   --ants-input /path/to/existing/ants-seg \

--- a/Singularity
+++ b/Singularity
@@ -130,4 +130,4 @@ From: ubuntu:22.04
       singularity run [container] [input_dir] [output_dir] participant [options]
 
     Example:
-      singularity run ants-nidm-bidsapp.sif $PWD/inputs/data/BIDS $PWD/outputs/ants participant --participant-label 01 02 03 --session-label 01 --modality T1w
+      singularity run ants-nidm_bidsapp.sif $PWD/inputs/data/BIDS $PWD/outputs/ants participant --participant-label 01 02 03 --session-label 01 --modality T1w

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ examples/
 To run the ANTs BIDS App on this example data:
 
 ```bash
-ants-bidsapp examples output participant --participant-label 01 02
+ants-nidm examples output participant --participant-label 01 02
 ```
 
 ## Note

--- a/setup.py
+++ b/setup.py
@@ -5,24 +5,31 @@ from pathlib import Path
 from setuptools import setup, find_namespace_packages
 
 
+# Container image constants - single source of truth for image names
+DOCKER_IMAGE_NAME = "ants-nidm_bidsapp"
+DOCKER_IMAGE_TAG = "latest"
+DOCKER_IMAGE = f"{DOCKER_IMAGE_NAME}:{DOCKER_IMAGE_TAG}"
+SINGULARITY_IMAGE_NAME = f"{DOCKER_IMAGE_NAME}.sif"
+
+
 def build_docker():
     """Build Docker container"""
     print("Building Docker image...")
     try:
-        subprocess.run(["docker", "build", "-t", "ants-nidm_bidsapp:latest", "."], check=True)
-        print("Docker image built successfully: ants-nidm_bidsapp:latest")
+        subprocess.run(["docker", "build", "-t", DOCKER_IMAGE, "."], check=True)
+        print(f"Docker image built successfully: {DOCKER_IMAGE}")
     except subprocess.CalledProcessError as e:
         print(f"Docker build failed: {e}")
         return False
     return True
 
 
-def docker_to_singularity(docker_image="ants-nidm_bidsapp:latest", output_path=None):
+def docker_to_singularity(docker_image=DOCKER_IMAGE, output_path=None):
     """Convert Docker image to Singularity container"""
     print(f"Converting Docker image {docker_image} to Singularity...")
 
     # Use custom output path if provided, otherwise use default
-    output_file = output_path if output_path else "ants-nidm_bidsapp.sif"
+    output_file = output_path if output_path else SINGULARITY_IMAGE_NAME
     output_file = str(Path(output_file).resolve())
     
     try:
@@ -59,7 +66,7 @@ def build_singularity(output_path=None):
         ):
             print("\nDetected Apptainer on cluster environment.")
             print("For cluster environments, please build directly with apptainer:")
-            print("apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity\n")
+            print(f"apptainer build --fakeroot {SINGULARITY_IMAGE_NAME} Singularity\n")
             return False
         elif (
             subprocess.run(["which", "singularity"], capture_output=True).returncode == 0
@@ -70,7 +77,7 @@ def build_singularity(output_path=None):
             return False
 
         # Use custom output path if provided, otherwise use default
-        output_file = output_path if output_path else "ants-nidm_bidsapp.sif"
+        output_file = output_path if output_path else SINGULARITY_IMAGE_NAME
         output_file = str(Path(output_file).resolve())
         
         # Build command
@@ -92,9 +99,9 @@ def build_singularity(output_path=None):
     except subprocess.CalledProcessError as e:
         print(f"Build failed: {e}")
         print("\nFor cluster environments, please build directly with apptainer:")
-        print("apptainer build --remote ants-nidm_bidsapp.sif Singularity")
+        print(f"apptainer build --remote {SINGULARITY_IMAGE_NAME} Singularity")
         print("or")
-        print("apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity")
+        print(f"apptainer build --fakeroot {SINGULARITY_IMAGE_NAME} Singularity")
         return False
 
 
@@ -126,7 +133,7 @@ def print_usage():
     print("\nOther Commands:")
     print("  python setup.py --init-git       - Initialize git submodules")
     print("\nNote: For HPC environments without Docker, use 'singularity' command directly:")
-    print("  apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity")
+    print(f"  apptainer build --fakeroot {SINGULARITY_IMAGE_NAME} Singularity")
     print("\nFor more information, run: python setup.py --help")
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,20 +9,20 @@ def build_docker():
     """Build Docker container"""
     print("Building Docker image...")
     try:
-        subprocess.run(["docker", "build", "-t", "ants-nidm-bidsapp:latest", "."], check=True)
-        print("Docker image built successfully: ants-nidm-bidsapp:latest")
+        subprocess.run(["docker", "build", "-t", "ants-nidm_bidsapp:latest", "."], check=True)
+        print("Docker image built successfully: ants-nidm_bidsapp:latest")
     except subprocess.CalledProcessError as e:
         print(f"Docker build failed: {e}")
         return False
     return True
 
 
-def docker_to_singularity(docker_image="ants-nidm-bidsapp:latest", output_path=None):
+def docker_to_singularity(docker_image="ants-nidm_bidsapp:latest", output_path=None):
     """Convert Docker image to Singularity container"""
     print(f"Converting Docker image {docker_image} to Singularity...")
 
     # Use custom output path if provided, otherwise use default
-    output_file = output_path if output_path else "ants-nidm-bidsapp.sif"
+    output_file = output_path if output_path else "ants-nidm_bidsapp.sif"
     output_file = str(Path(output_file).resolve())
     
     try:
@@ -59,7 +59,7 @@ def build_singularity(output_path=None):
         ):
             print("\nDetected Apptainer on cluster environment.")
             print("For cluster environments, please build directly with apptainer:")
-            print("apptainer build --fakeroot ants-nidm-bidsapp.sif Singularity\n")
+            print("apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity\n")
             return False
         elif (
             subprocess.run(["which", "singularity"], capture_output=True).returncode == 0
@@ -70,7 +70,7 @@ def build_singularity(output_path=None):
             return False
 
         # Use custom output path if provided, otherwise use default
-        output_file = output_path if output_path else "ants-nidm-bidsapp.sif"
+        output_file = output_path if output_path else "ants-nidm_bidsapp.sif"
         output_file = str(Path(output_file).resolve())
         
         # Build command
@@ -92,9 +92,9 @@ def build_singularity(output_path=None):
     except subprocess.CalledProcessError as e:
         print(f"Build failed: {e}")
         print("\nFor cluster environments, please build directly with apptainer:")
-        print("apptainer build --remote ants-nidm-bidsapp.sif Singularity")
+        print("apptainer build --remote ants-nidm_bidsapp.sif Singularity")
         print("or")
-        print("apptainer build --fakeroot ants-nidm-bidsapp.sif Singularity")
+        print("apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity")
         return False
 
 
@@ -126,7 +126,7 @@ def print_usage():
     print("\nOther Commands:")
     print("  python setup.py --init-git       - Initialize git submodules")
     print("\nNote: For HPC environments without Docker, use 'singularity' command directly:")
-    print("  apptainer build --fakeroot ants-nidm-bidsapp.sif Singularity")
+    print("  apptainer build --fakeroot ants-nidm_bidsapp.sif Singularity")
     print("\nFor more information, run: python setup.py --help")
 
 
@@ -242,7 +242,7 @@ if "install" in sys.argv:
     print("  python -m pip install -e .")
 
 setup(
-    name="ants-nidm_bidsapp",
+    name="ants-nidm",
     version="0.1.0",
     description="BIDS App for ANTs Segmentation with NIDM Output",
     author="ReproNim",
@@ -263,7 +263,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "ants-nidm-bidsapp=src.run:main",
+            "ants-nidm=src.run:main",
         ],
     },
     python_requires=">=3.9",

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -99,7 +99,7 @@ class ANTsSegmentation:
         self.verbose = verbose
         
         # Set up logging
-        self.logger = logging.getLogger('ants_bidsapp.segmentation')
+        self.logger = logging.getLogger('ants-nidm.segmentation')
         
         # Validate required directories
         if not self.bids_dir or not self.bids_dir.exists():

--- a/src/run.py
+++ b/src/run.py
@@ -29,7 +29,7 @@ def setup_logger(log_dir, verbose=False):
     """Set up logging configuration."""
     os.makedirs(log_dir, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_file = os.path.join(log_dir, f"ants-nidm_bidsapp-{timestamp}.log")
+    log_file = os.path.join(log_dir, f"ants-nidm-{timestamp}.log")
     
     # Configure logging
     log_level = logging.DEBUG if verbose else logging.INFO
@@ -41,7 +41,7 @@ def setup_logger(log_dir, verbose=False):
             logging.StreamHandler()
         ]
     )
-    return logging.getLogger('ants-nidm_bidsapp')
+    return logging.getLogger('ants-nidm')
 
 def find_nidm_input_file(nidm_input_dir, subject_id, session_id=None):
     """Search for NIDM input file in standard locations.


### PR DESCRIPTION
This pull request standardizes the naming conventions across the project by replacing all instances of `ants-nidm-bidsapp` and similar variants with `ants-nidm` or `ants-nidm_bidsapp`, depending on the context. This affects Docker/Singularity image names, command-line usage, logging, and the Python package name, resulting in more consistent and user-friendly commands and documentation.

**Container and Command Naming Updates:**

- Changed all Docker and Singularity image names and related commands in `README.md`, `setup.py`, and `Singularity` from `ants-nidm-bidsapp` to `ants-nidm_bidsapp` for clarity and consistency. This includes build, save, and run commands, as well as references in documentation and example usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R85) [[3]](diffhunk://#diff-10b7d5be25093a4d318efd8639b6e34583bad10bf38adbf93b4c3733ea54221bL133-R133) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L12-R25) [[5]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L62-R62) [[6]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L73-R73) [[7]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L95-R97) [[8]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L129-R129)

- Updated the command-line entry point and all usage examples from `ants-nidm-bidsapp` or `ants-bidsapp` to `ants-nidm` for a simpler and more intuitive user experience. [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L25-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R85) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L266-R266)

**Python Package and Logging Renaming:**

- Changed the Python package name in `setup.py` from `ants-nidm_bidsapp` to `ants-nidm` and updated the logger names throughout the codebase to match the new naming convention. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L245-R245) [[2]](diffhunk://#diff-836b24b11b433763000e2ba739f337964d6ea4ee0315884870818452995ef6bbL102-R102) [[3]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L32-R32) [[4]](diffhunk://#diff-525565c956f875698bc74ac798b474aa561f4570464b770434888cfbf34bde48L44-R44)

**Entrypoint and Script Updates:**

- Modified the Docker entrypoint script to call `ants-nidm` instead of the old `ants-nidm-bidsapp` executable.

These changes ensure that the project uses a consistent and simplified naming scheme, which will reduce confusion for users and developers alike.