### PR TITLE
Update BABS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ ants-nidm bids_dir output_dir participant \
   --nidm-input-dir /path/to/nidm/inputs
 ```
 
+### BABS compatibility
+
+The app supports both the original BABS project layout and the configurable
+BIDS-study layout introduced by
+[PennLINC/babs PR #369](https://github.com/PennLINC/babs/pull/369). See
+[`examples/babs-ants-nidm-bids-study.yaml`](examples/babs-ants-nidm-bids-study.yaml)
+for a complete new-layout template; remove its three path settings to retain
+BABS's legacy defaults.
+
+BABS uses the positional analysis level `participant` even for session-wise
+jobs and supplies the session through `$SESSION_SELECTION_FLAG`. When
+`--session-label` accompanies participant mode, this app runs its existing
+session pipeline so only the requested session is segmented and converted.
+
 ### Command-line Arguments
 
 **Required:**

--- a/examples/babs-ants-nidm-bids-study.yaml
+++ b/examples/babs-ants-nidm-bids-study.yaml
@@ -1,0 +1,51 @@
+# Example BABS configuration for ants-nidm 0.1.0 using the BIDS-study layout
+# added by PennLINC/babs PR #369.
+
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
+input_datasets:
+    BIDS:
+        required_files:
+            - "anat/*_T1w.nii*"
+        is_zipped: false
+        origin_url: "/path/to/BIDS"
+        path_in_babs: sourcedata/BIDS
+    NIDM:
+        required_files:
+            - "nidm.ttl"
+        is_zipped: false
+        origin_url: "/path/to/NIDM"
+        path_in_babs: sourcedata/NIDM
+
+bids_app_args:
+    $SUBJECT_SELECTION_FLAG: "--participant-label"
+    # For a BABS project initialized with processing level "session", uncomment:
+    # $SESSION_SELECTION_FLAG: "--session-label"
+    --num-threads: "8"
+
+singularity_args:
+    - --cleanenv
+    - --containall
+    - --writable-tmpfs
+
+zip_foldernames:
+    ants-nidm_bidsapp: "0-1-0"
+
+cluster_resources:
+    interpreting_shell: "/bin/bash"
+    hard_runtime_limit: "18:00:00"
+    temporary_disk_space: 50G
+    customized_text: |
+        #SBATCH --nodes=1
+        #SBATCH --ntasks=1
+        #SBATCH --cpus-per-task=8
+        #SBATCH --mem=32G
+        #SBATCH --propagate=NONE
+
+script_preamble: |
+    # Load site-specific Apptainer/DataLad modules or activate BABS here.
+    module load apptainer
+
+job_compute_space: "/path/to/temporary_compute_space"

--- a/src/run.py
+++ b/src/run.py
@@ -344,7 +344,14 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
         return False
 
 def process_participant(args, logger):
-    """Run the participant level analysis for single-session datasets."""
+    """Run participant analysis, including BABS session-wise invocations."""
+    if args.session_label:
+        logger.info(
+            "Session label supplied with participant analysis level; "
+            "processing the requested session"
+        )
+        return process_session(args, logger)
+
     logger.info("Starting participant level analysis (single-session dataset)")
 
     # Initialize app

--- a/tests/test_babs_config.py
+++ b/tests/test_babs_config.py
@@ -1,0 +1,16 @@
+"""Regression checks for the documented BABS PR #369 configuration."""
+
+from pathlib import Path
+
+
+def test_bids_study_config_declares_new_babs_paths():
+    root = Path(__file__).parents[1]
+    config = (root / "examples" / "babs-ants-nidm-bids-study.yaml").read_text()
+
+    assert 'analysis_path: "."' in config
+    assert 'input_ria_path: ".babs/input_ria"' in config
+    assert 'output_ria_path: ".babs/output_ria"' in config
+    assert 'path_in_babs: sourcedata/BIDS' in config
+    assert '$SUBJECT_SELECTION_FLAG: "--participant-label"' in config
+    assert '# $SESSION_SELECTION_FLAG: "--session-label"' in config
+    assert 'ants-nidm_bidsapp: "0-1-0"' in config

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -332,6 +332,16 @@ class TestRun(unittest.TestCase):
             mock_instance.run_subject.assert_called_once()
             mock_nidm.assert_called_once()
 
+    def test_participant_level_with_session_uses_session_pipeline(self):
+        """BABS supplies sessions while retaining positional participant mode."""
+        args = MagicMock(session_label="ses-01")
+
+        with patch("src.run.process_session", return_value=0) as mock_session:
+            result = process_participant(args, self.logger)
+
+        self.assertEqual(result, 0)
+        mock_session.assert_called_once_with(args, self.logger)
+
     @unittest.skipIf(IN_CI, "Skip in CI environment as it requires modifying template directory")
     def test_process_session(self):
         """Test session level processing with NIDM conversion"""


### PR DESCRIPTION
## Summary

- treat `participant --session-label ...` as a session-wise request, matching BABS-generated commands
- add a BABS PR #369 configuration example using root analysis, `.babs` RIA stores, and `sourcedata` inputs
- document new- and legacy-layout usage
- add regression tests for session routing and the documented configuration

## Why

BABS session jobs invoke BIDS Apps with positional analysis level `participant` and provide the session separately through `$SESSION_SELECTION_FLAG`. ANTs-NIDM accepted `--session-label`, but participant mode discarded it and ran the single-session path. This could process the wrong scope or fail on multi-session input.

## Impact

BABS session jobs now reuse ANTs-NIDM's existing session pipeline and restrict segmentation and NIDM conversion to the requested session. Direct `session` analysis and participant jobs without a session label retain their existing behavior. The example supports BABS's configurable BIDS-study layout while documenting how to retain legacy defaults.

## Validation

- `PYTHONPATH=$PWD python -m pytest -q` — 15 passed
- Python compilation of changed Python files
- generated subject- and session-level scripts against BABS PR #369 merge commit `2cc536a`
- verified configured root/`.babs` paths and legacy BABS path defaults
- `git diff --check`
