### PR TITLE
Per-subject output layout, hardening pass, and six run-blocking fixes found by the first real run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,15 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        # src/ants_seg_to_nidm is a submodule. Without this the directory is
+        # empty on a clean runner, so nothing here ever exercises the NIDM
+        # converter -- and the container build below would produce an image
+        # with no converter in it.
+        submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,4 +32,27 @@ jobs:
         pip install pytest pytest-cov
     - name: Run tests
       run: |
-        pytest --cov=src tests/ 
+        pytest --cov=src tests/
+
+  docker-build:
+    # Validates that the image actually builds from a clean checkout, on PRs as
+    # well as pushes -- a push-only build job can hide a real breakage for
+    # months. Singularity is deliberately NOT built in CI: on GitHub-hosted
+    # runners the unprivileged user-namespace restriction makes `apptainer
+    # build` hang for hours rather than fail, see
+    # ReproNim/freesurfer-nidm_bidsapp#12.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - name: Build Docker image
+      run: |
+        docker build -t ants-nidm_bidsapp:ci .
+    - name: Smoke-test entrypoint
+      run: |
+        docker run --rm ants-nidm_bidsapp:ci --version

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ CLAUDE.md
 
 # Internal documentation and team files
 internal/
+
+# serena MCP server project cache
+.serena/

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,13 +57,20 @@ WORKDIR /app
 
 # Copy application code
 COPY setup.py /app/
+COPY requirements.txt /app/
 COPY src/ /app/src/
 COPY README.md /app/
 
-# Install the application and NIDM conversion toolkit
-RUN pip3 install -e . && \
-    pip3 install -e src/ants_seg_to_nidm && \
-    pip3 install -r src/ants_seg_to_nidm/requirements.txt && \
+# Install the application and NIDM conversion toolkit.
+# Order matters and mirrors Singularity (and the sibling freesurfer-nidm app):
+# the NIDM submodule first with its loose deps, then the top-level
+# requirements.txt applies the authoritative pins on top. The submodule's own
+# requirements.txt is deliberately NOT installed -- it pins pynidm==4.2.4, which
+# would silently override the 4.5.0 pin here.
+RUN pip3 install -e src/ants_seg_to_nidm && \
+    pip3 install -r requirements.txt && \
+    pip3 install --no-cache-dir --upgrade 'rdflib>=7.0.0,<8' && \
+    pip3 install -e . && \
     chmod -R 755 /app
 
 # Set environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,19 +37,48 @@ RUN mkdir -p /opt/data && chmod 755 /opt/data
 # Download OASIS templates and atlases
 WORKDIR /opt/data
 
-# Download OASIS-30 Atropos template
-RUN wget -q https://files.osf.io/v1/resources/ej52r/providers/osfstorage/5e8251d20f59a8001ae648c3/?zip= \
+# Download the OASIS templates and atlases.
+#
+# These URLs mirror Singularity exactly and must stay in sync with it. The two
+# recipes had drifted apart: this file pointed at OSF resource ej52r, which now
+# returns HTTP 500, so `docker build` failed at this step -- and it never
+# downloaded the jointfusion labels at all, so even a successful build produced
+# an image where --method quick aborts with "Template labels not found". The
+# Singularity URLs below are the ones that actually resolve.
+
+# OASIS-30 Atropos template (preprocessing + Atropos priors)
+RUN wget -q "https://osf.io/rh9km/?action=download&version=1" \
     -O OASIS-30_Atropos_template.zip && \
-    unzip -q OASIS-30_Atropos_template.zip && \
+    unzip -q -o OASIS-30_Atropos_template.zip && \
     rm OASIS-30_Atropos_template.zip && \
     chmod -R 755 /opt/data/OASIS-30_Atropos_template
 
-# Download OASIS-TRT-20 atlases for joint label fusion
-RUN wget -q https://files.osf.io/v1/resources/ej52r/providers/osfstorage/5e825d0f2301130197e6a15e/?zip= \
-    -O OASIS-TRT-20.zip && \
-    unzip -q OASIS-TRT-20.zip && \
-    rm OASIS-TRT-20.zip && \
-    chmod -R 755 /opt/data/OASIS-TRT-20_*
+# OASIS-TRT-20 atlas brains for joint label fusion
+RUN wget -q "https://files.osf.io/v1/resources/hs8am/providers/osfstorage/57c1a8f06c613b01f98d68a9/?zip=" \
+    -O OASIS-TRT-20_brains.zip && \
+    unzip -q -o OASIS-TRT-20_brains.zip -d OASIS-TRT-20_brains && \
+    rm OASIS-TRT-20_brains.zip
+
+# Matching DKT31/CMA labels for those atlases
+RUN wget -q "https://files.osf.io/v1/resources/hs8am/providers/osfstorage/57c1a8ffb83f690201c4a8be/?zip=" \
+    -O OASIS-TRT-20_DKT31_CMA_labels_v2.zip && \
+    unzip -q -o OASIS-TRT-20_DKT31_CMA_labels_v2.zip -d OASIS-TRT-20_DKT31_CMA_labels_v2 && \
+    rm OASIS-TRT-20_DKT31_CMA_labels_v2.zip
+
+# Pre-computed jointfusion labels in OASIS-30 space, required by --method quick
+RUN wget -q "https://osf.io/download/nxg5t/" \
+    -O OASIS-TRT-20_jointfusion_DKT31_CMA_labels_in_OASIS-30_v2.nii.gz
+
+# Both atlas archives may unpack with a redundant nesting level; flatten it so
+# the wrapper's expected paths resolve (same fix-up Singularity performs).
+RUN for d in OASIS-TRT-20_brains OASIS-TRT-20_DKT31_CMA_labels_v2; do \
+        if [ -d "$d/$d" ]; then \
+            echo "Flattening nested $d"; \
+            mv "$d/$d"/* "$d"/ && rmdir "$d/$d"; \
+        fi; \
+    done && \
+    chmod -R 755 /opt/data && \
+    ls -la /opt/data
 
 # Create app directory with proper permissions
 RUN mkdir -p /app && chmod 755 /app

--- a/README.md
+++ b/README.md
@@ -137,31 +137,38 @@ ants-nidm bids_dir output_dir participant \
 
 ## Outputs
 
-The app generates the following output structure:
+The app generates the following output structure. Everything produced for one
+subject lives under `sub-XX/` -- that directory is the unit BABS zips, so two
+subjects can never write to the same path:
 
 ```
 output_dir/
-├── ants-nidm_bidsapp/                          # Main BIDS App output directory
-│   ├── ants-seg/                               # ANTs segmentation derivatives
-│   │   ├── dataset_description.json
-│   │   └── sub-XX/
-│   │       ├── ses-YY/                         # For multi-session datasets
-│   │       │   ├── anat/
-│   │       │   │   ├── sub-XX_ses-YY_T1w_space-orig_dseg.nii.gz
-│   │       │   │   ├── sub-XX_ses-YY_T1w_BrainSegmentation.nii.gz
-│   │       │   │   └── sub-XX_ses-YY_T1w_BrainSegmentationPosteriors*.nii.gz
-│   │       │   └── stats/
-│   │       │       ├── sub-XX_ses-YY_antslabelstats.csv
-│   │       │       └── sub-XX_ses-YY_antsbrainvols.csv
-│   │       └── anat/, stats/                   # For single-session datasets (no ses-)
-│   └── nidm/                                   # NIDM outputs (flat structure)
-│       ├── dataset_description.json
-│       ├── sub-01_ses-baseline.ttl            # NIDM files (Turtle format)
-│       └── sub-02_ses-baseline.ttl
+├── dataset_description.json                    # Derivative-root metadata (not part of the per-subject zip)
+├── sub-XX/                                     # Single-session datasets
+│   ├── anat/
+│   │   ├── sub-XX_T1w_space-orig_dseg.nii.gz
+│   │   ├── sub-XX_T1w_BrainSegmentation.nii.gz
+│   │   └── sub-XX_T1w_BrainSegmentationPosteriors*.nii.gz
+│   ├── stats/
+│   │   ├── sub-XX_antslabelstats.csv
+│   │   └── sub-XX_antsbrainvols.csv
+│   ├── nidm.ttl                                # Input NIDM augmented with ANTs metrics
+│   └── ants_cde.ttl                            # Shared CDE vocabulary, shipped alongside
+├── sub-YY/
+│   └── ses-ZZ/                                 # Multi-session datasets nest a session level
+│       ├── anat/, stats/
+│       ├── nidm.ttl
+│       └── ants_cde.ttl
 └── logs/                                       # Processing logs
 ```
 
-**Note:** NIDM outputs use a **flat file structure** (all TTL files in one directory) rather than hierarchical subdirectories. This design choice simplifies file management and discovery. See CLAUDE.md for detailed rationale.
+**NIDM layout:** the output is always named `nidm.ttl` and subject identity is
+carried by the directory. There is deliberately no app-name wrapper directory
+and no shared `nidm/` directory: a shared `nidm/nidm.ttl` made every subject's
+NIDM collide on one path, and `unzip -n` at BABS merge time silently kept only
+the first subject's copy. `ants_cde.ttl` is a static, byte-identical vocabulary
+required to resolve the `ants_*` predicates; it is shipped next to `nidm.ttl`
+rather than merged into it, matching the sibling FreeSurfer and FSL apps.
 
 Output files include:
 - **Segmentation results** in BIDS-derivatives format

--- a/Singularity
+++ b/Singularity
@@ -87,15 +87,20 @@ From: ubuntu:22.04
     echo "Labels directory contents:"
     ls -la /opt/data/OASIS-TRT-20_DKT31_CMA_labels_v2/ | head -5
 
-    # Install Python dependencies and application code
-    cd /opt
-    python3 -m pip install -r requirements.txt
-    python3 -m pip install -e .
-
-    # Install ants_seg_to_nidm and its requirements
+    # Install Python dependencies and application code.
+    # Order matters and mirrors the Dockerfile (and the sibling freesurfer-nidm
+    # app): the NIDM submodule goes in first with its loose deps, then the
+    # top-level requirements.txt applies the authoritative pins on top. The
+    # submodule's own requirements.txt is deliberately NOT installed -- it pins
+    # pynidm==4.2.4, which would silently override the 4.5.0 pin here.
     cd /opt/src/ants_seg_to_nidm
     python3 -m pip install -e .
+
+    cd /opt
     python3 -m pip install -r requirements.txt
+    # oxrdflib (pulled in by pynidm 4.5.0) requires rdflib<8; pynidm wants >=7.
+    python3 -m pip install --no-cache-dir --upgrade 'rdflib>=7.0.0,<8'
+    python3 -m pip install -e .
 
     # Mirror Docker's writable scratch directory
     mkdir -p /work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,20 @@
+# Main dependencies
 antspyx
 nibabel>=4.0.0
 numpy>=1.20.0
 pybids>=0.15.1
 pytest>=7.0.0
 natsort>=8.0.0
+# NIDM stack. Kept in lockstep with the sibling freesurfer-nidm app: the shared
+# NIDM input datasets (derivatives/nidm_4.5.0) are produced with PyNIDM 4.5.0,
+# and this file -- not src/ants_seg_to_nidm/requirements.txt -- is the single
+# source of truth for the container's NIDM pins.
+pynidm==4.5.0
+# PyNIDM 4.5.0 adds an oxigraph-backed rdflib store; pinned explicitly so the
+# runtime dep is visible. Requires rdflib<8 (see build files' rdflib upgrade).
+oxrdflib~=0.5.0
+# prov 3.0.0 moved NetworkX graph interop to the optional "graph" extra; pynidm's
+# nidm.experiment modules import prov.graph, so the extra (networkx) is required.
+# Without it `import ants_seg_to_nidm` dies with ModuleNotFoundError and every
+# NIDM conversion fails.
+prov[graph]

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -356,28 +356,19 @@ class ANTsSegmentation:
                 
             template_labels = ants.image_read(str(self.template_labels_path))
             
-            # Apply template-to-subject transforms to labels
-            # Build transform list based on what's available
-            transformlist = []
-            whichtoinvert = []
-            
-            if thickness_results.get('TemplateToSubject1GenericAffine'):
-                transformlist.append(thickness_results['TemplateToSubject1GenericAffine'])
-                whichtoinvert.append(False)
-                
-            if thickness_results.get('TemplateToSubject0Warp'):
-                transformlist.append(thickness_results['TemplateToSubject0Warp'])
-                whichtoinvert.append(False)
-                
+            # Apply template-to-subject transforms to the label atlas. As above,
+            # whichtoinvert is left unset so ANTsPy infers it from the transform
+            # shapes; the previous code hardcoded False for every element, which
+            # is wrong for the affine in an invtransforms list.
+            transformlist = thickness_results.get('TemplateToSubjectTransforms') or []
             if not transformlist:
                 raise ValueError("No transforms available for template-to-subject mapping")
-                
+
             warped_labels = ants.apply_transforms(
                 fixed=thickness_results['BrainSegmentationN4'],
                 moving=template_labels,
                 transformlist=transformlist,
-                interpolator='nearestNeighbor',
-                whichtoinvert=whichtoinvert
+                interpolator='nearestNeighbor'
             )
             
             return {
@@ -551,31 +542,46 @@ class ANTsSegmentation:
         label_df.to_csv(labelstats_file, index=False)
 
         # Generate antsbrainvols.csv
+        #
+        # Only BVOL is reported. This used to also emit CSFVOL/GMVOL/WMVOL from
+        # probabilityimages[0], [1] and [2], on the assumption that those are
+        # CSF/GM/WM tissue posteriors. They are not, in either method:
+        #   - 'fusion' returns one posterior per *anatomical label* (103 of them
+        #     on ABIDE sub-0051456), so [0..2] were simply the first three DKT
+        #     labels wearing tissue names -- delivered CSFVOL/GMVOL/WMVOL of
+        #     4105/5426/10391 mm^3 against ~1.5e5/6.0e5/5.0e5 expected.
+        #   - 'quick' returns no 'probabilityimages' key at all, so the branch
+        #     never ran there.
+        # That is every code path, so the columns were wrong whenever present.
+        # Deriving real tissue volumes means grouping DKT labels into tissue
+        # classes (or running Atropos for posteriors), which is a separate piece
+        # of work; reporting nothing beats reporting numbers off by ~100x.
         brain_vol_data = {"BVOL": brain_volume}
-        tissue_volumes = {}
-
-        probability_images = segmentation.get('probabilityimages') or []
-        if len(probability_images) >= 3:
-            csf_vol = float(np.sum(probability_images[0].numpy() > self.prob_threshold) * voxel_volume)
-            gm_vol = float(np.sum(probability_images[1].numpy() > self.prob_threshold) * voxel_volume)
-            wm_vol = float(np.sum(probability_images[2].numpy() > self.prob_threshold) * voxel_volume)
-
-            tissue_volumes = {
-                "CSFVOL": csf_vol,
-                "GMVOL": gm_vol,
-                "WMVOL": wm_vol,
-            }
-            brain_vol_data.update(tissue_volumes)
 
         brainvols_file = stats_dir / f"{seg_base}_antsbrainvols.csv"
         pd.DataFrame([brain_vol_data]).to_csv(brainvols_file, index=False)
 
-        # Save probability maps if available
-        if 'probabilityimages' in segmentation:
-            for idx, prob_img in enumerate(segmentation['probabilityimages']):
-                prob_filename = f"sub-{bids_subject}{session_part}_space-orig_label-{idx+1}_probseg.nii.gz"
-                prob_path = anat_dir / prob_filename
-                ants.image_write(prob_img, str(prob_path))
+        # Save probability maps if available.
+        # Name each map by the anatomical label it belongs to, taken from
+        # segmentation_numbers, rather than by its position in the list. The
+        # index-based names (label-1 ... label-104) did not correspond to any
+        # label in the segmentation, so the maps could not be matched to the
+        # structures they describe.
+        prob_images = segmentation.get('probabilityimages') or []
+        seg_numbers = segmentation.get('segmentation_numbers') or []
+        if prob_images and len(seg_numbers) != len(prob_images):
+            self.logger.warning(
+                f"{len(prob_images)} probability maps but {len(seg_numbers)} label "
+                "numbers; falling back to index-based probseg names"
+            )
+        for idx, prob_img in enumerate(prob_images):
+            if len(seg_numbers) == len(prob_images):
+                label_id = int(seg_numbers[idx])
+            else:
+                label_id = idx + 1
+            prob_filename = f"sub-{bids_subject}{session_part}_space-orig_label-{label_id}_probseg.nii.gz"
+            prob_path = anat_dir / prob_filename
+            ants.image_write(prob_img, str(prob_path))
         
         self.logger.info(f"Saved segmentation results for subject {bids_subject}")
         volume_info = {
@@ -585,9 +591,6 @@ class ANTsSegmentation:
             'segmentation': str(label_path),
             'label_volumes': {int(lbl): float(vol) for lbl, vol in zip(label_values, label_volumes_mm3)},
         }
-
-        if tissue_volumes:
-            volume_info['tissue_volumes'] = tissue_volumes
 
         return volume_info
 
@@ -703,9 +706,8 @@ class ANTsSegmentation:
             # Log volume information
             if volumes:
                 self.logger.info("Segmentation volumes:")
-                if 'tissue_volumes' in volumes:
-                    for tissue, volume in volumes['tissue_volumes'].items():
-                        self.logger.info(f"  {tissue}: {volume:.2f} mm³")
+                if 'brain_volume' in volumes:
+                    self.logger.info(f"  BVOL: {volumes['brain_volume']:.2f} mm³")
                 if 'label_volumes' in volumes:
                     for label, volume in volumes['label_volumes'].items():
                         self.logger.info(f"  Label {label}: {volume:.2f} mm³")
@@ -803,17 +805,30 @@ class ANTsSegmentation:
                 random_seed=1
             )
             
-            transforms = [
-                reg['fwdtransforms'][0],  # Affine transform
-                reg['fwdtransforms'][1]   # Warp transform
-            ]
-            
+            # These registrations are subject -> template (fixed=brain_template,
+            # moving=brain_image), so fwdtransforms maps subject -> template.
+            # Everything downstream needs the opposite direction -- pulling
+            # template-space images (the extraction mask, and the label atlas in
+            # the 'quick' method) into subject space -- which is invtransforms:
+            # "invtransforms: Transforms to move from fixed to moving image".
+            #
+            # Using fwdtransforms here yielded a mask covering the entire FOV, so
+            # joint label fusion labelled air, skull and neck: 100% of voxels
+            # labelled, no background at all, label 4 alone taking 69.6% of the
+            # image, and an 11.5 L "brain volume" on ABIDE sub-0051456. The
+            # initial-mask call above was always correct; only this one was not.
+            transforms = list(reg['invtransforms'])
+
         except Exception as e:
             self.logger.warning(f"SyN registration failed: {str(e)}")
             self.logger.info("Using affine registration only")
-            transforms = [affine_reg['fwdtransforms'][0]]
-        
-        # Apply final transforms to extraction mask
+            transforms = list(affine_reg['invtransforms'])
+
+        # Apply final transforms to extraction mask.
+        # whichtoinvert is deliberately left unset: apply_transforms auto-detects
+        # the (True, False) pattern for the [affine.mat, InverseWarp] shape that
+        # invtransforms returns. Hand-maintaining that bookkeeping per element is
+        # what went wrong before, so it is not reintroduced here.
         ext_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumExtractionMask.nii.gz'))
         final_mask = ants.apply_transforms(
             fixed=n4_image,
@@ -833,17 +848,9 @@ class ANTsSegmentation:
             'BrainExtractionMask': final_mask
         }
         
-        # Handle transforms based on what's available
-        if len(transforms) > 1:
-            results['TemplateToSubject1GenericAffine'] = transforms[0]
-            results['TemplateToSubject0Warp'] = transforms[1]
-        elif len(transforms) == 1:
-            # Only affine available
-            results['TemplateToSubject1GenericAffine'] = transforms[0]
-            results['TemplateToSubject0Warp'] = None
-        else:
-            # No transforms (shouldn't happen but handle gracefully)
-            results['TemplateToSubject1GenericAffine'] = None
-            results['TemplateToSubject0Warp'] = None
-            
+        # Template -> subject transforms, kept as the ordered list ANTsPy
+        # returned. Consumers pass it to apply_transforms verbatim rather than
+        # rebuilding it element by element.
+        results['TemplateToSubjectTransforms'] = transforms
+
         return results

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -629,6 +629,7 @@ class ANTsSegmentation:
                     'T_template': 'T_template0.nii.gz',
                     'BrainCerebellum': 'T_template0_BrainCerebellum.nii.gz',
                     'ProbabilityMask': 'T_template0_BrainCerebellumProbabilityMask.nii.gz',
+                    'ExtractionMask': 'T_template0_BrainCerebellumExtractionMask.nii.gz',
                     'priors_dir': 'Priors2'
                 },
                 'template_description': 'OASIS-30 Atropos template'
@@ -742,16 +743,29 @@ class ANTsSegmentation:
             spline_param=200
         )
         
-        # Initial brain extraction using registration template and probability mask
+        # Initial brain extraction, antsBrainExtraction.sh semantics: register
+        # the whole-head subject to the whole-head T_template0 with the
+        # ExtractionMask restricting the metric region (that is what that
+        # 5.9 L mask is for), then pull the brain probability mask into
+        # subject space. The previous init registered whole-head onto the
+        # brain-only BrainCerebellum template, rigid-only and unmasked --
+        # content-mismatched and without scaling, which turned out bistable
+        # across CPU types: identical code and input gave a 1.70 L final mask
+        # on node1406, 2.84 L on node2906 and 3.25 L on node2000. Affine (so
+        # head size lands in the transform, not the mask) plus matched content
+        # plus the metric mask keeps every node in the same basin.
         self.logger.info("Performing initial brain extraction")
+        head_template = ants.image_read(str(self.template_dir / 'T_template0.nii.gz'))
         reg_template = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellum.nii.gz'))
         prob_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumProbabilityMask.nii.gz'))
-        
-        # Initial rigid registration
+        extraction_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumExtractionMask.nii.gz'))
+
+        # Initial affine registration, metric restricted to the head region
         init_reg = ants.registration(
-            fixed=reg_template,
+            fixed=head_template,
             moving=n4_image,
-            type_of_transform='Rigid',
+            type_of_transform='Affine',
+            mask=extraction_mask,
             aff_metric='mattes',
             aff_sampling=32,
             aff_random_sampling_rate=0.2,
@@ -759,13 +773,13 @@ class ANTsSegmentation:
             verbose=True,
             random_seed=1
         )
-        
+
         # Transform probability mask to subject space
         init_mask = ants.apply_transforms(
             fixed=n4_image,
             moving=prob_mask,
             transformlist=init_reg['invtransforms'],
-            interpolator='lanczosWindowedSinc'
+            interpolator='linear'
         )
         
         # Create brain mask and extract brain

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -629,7 +629,6 @@ class ANTsSegmentation:
                     'T_template': 'T_template0.nii.gz',
                     'BrainCerebellum': 'T_template0_BrainCerebellum.nii.gz',
                     'ProbabilityMask': 'T_template0_BrainCerebellumProbabilityMask.nii.gz',
-                    'ExtractionMask': 'T_template0_BrainCerebellumExtractionMask.nii.gz',
                     'priors_dir': 'Priors2'
                 },
                 'template_description': 'OASIS-30 Atropos template'
@@ -775,10 +774,15 @@ class ANTsSegmentation:
         brain_mask = ants.iMath(brain_mask, "GetLargestComponent")
         brain_image = n4_image * brain_mask
         
-        # Register to brain template
+        # Register to the brain-only template. brain_image is skull-stripped at
+        # this point, so the fixed image must be skull-stripped too
+        # (T_template0_BrainCerebellum, already loaded above as reg_template).
+        # Registering it onto the whole-head T_template0 biased the affine
+        # toward scaling the brain up to the head outline, inflating every
+        # template-space image warped back with these transforms.
         self.logger.info("Registering to template")
-        brain_template = ants.image_read(str(self.template_dir / 'T_template0.nii.gz'))
-        
+        brain_template = reg_template
+
         try:
             # First try affine registration
             affine_reg = ants.registration(
@@ -808,7 +812,7 @@ class ANTsSegmentation:
             # These registrations are subject -> template (fixed=brain_template,
             # moving=brain_image), so fwdtransforms maps subject -> template.
             # Everything downstream needs the opposite direction -- pulling
-            # template-space images (the extraction mask, and the label atlas in
+            # template-space images (the brain probability mask, and the label atlas in
             # the 'quick' method) into subject space -- which is invtransforms:
             # "invtransforms: Transforms to move from fixed to moving image".
             #
@@ -824,19 +828,25 @@ class ANTsSegmentation:
             self.logger.info("Using affine registration only")
             transforms = list(affine_reg['invtransforms'])
 
-        # Apply final transforms to extraction mask.
+        # Build the final brain mask from the warped *ProbabilityMask*, exactly
+        # as in the initial-extraction step above but through the refined
+        # affine+SyN transforms. NOT the ExtractionMask: in the OASIS-30 kit
+        # that file is the generous registration-scope mask (5.9 L in template
+        # space, antsBrainExtraction.sh's -f argument), not a brain mask --
+        # using it here delivered a 5.6 L "brain" on ABIDE sub-0051456 even
+        # with the transform direction fixed. The probability mask thresholded
+        # at 0.5 is 1.34 L, matching the brain-only template.
         # whichtoinvert is deliberately left unset: apply_transforms auto-detects
         # the (True, False) pattern for the [affine.mat, InverseWarp] shape that
         # invtransforms returns. Hand-maintaining that bookkeeping per element is
         # what went wrong before, so it is not reintroduced here.
-        ext_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumExtractionMask.nii.gz'))
         final_mask = ants.apply_transforms(
             fixed=n4_image,
-            moving=ext_mask,
+            moving=prob_mask,
             transformlist=transforms,
-            interpolator='nearestNeighbor'
+            interpolator='linear'
         )
-        
+
         # Ensure final mask is binary
         final_mask = ants.threshold_image(final_mask, 0.5, 1.0)
         final_mask = ants.iMath(final_mask, "FillHoles")

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -97,6 +97,15 @@ class ANTsSegmentation:
         self.prob_threshold = prob_threshold
         self.num_threads = num_threads
         self.verbose = verbose
+
+        # ANTsPy takes no threads argument: every ITK filter it calls reads
+        # ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS from the environment. The
+        # container pins that to 1 so an unconfigured run cannot oversubscribe a
+        # shared node, which meant --num-threads was accepted and then ignored --
+        # joint label fusion registers 20 atlases and is unusably slow at one
+        # thread. Set it here so --num-threads actually takes effect.
+        if self.num_threads and self.num_threads > 0:
+            os.environ["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(self.num_threads)
         
         # Set up logging
         self.logger = logging.getLogger('ants-nidm.segmentation')

--- a/src/run.py
+++ b/src/run.py
@@ -22,6 +22,10 @@ from src.antspy.wrapper import ANTsSegmentation
 # valid BIDSVersion value.
 BIDS_VERSION = "1.8.0"
 
+# App version. Kept in one place: initialize(), --version, and the per-subject
+# processing_summary.json all read it.
+APP_VERSION = "0.1.0"
+
 def setup_logger(log_dir, verbose=False):
     """Set up logging configuration."""
     os.makedirs(log_dir, exist_ok=True)
@@ -105,6 +109,73 @@ def find_nidm_input_file(nidm_input_dir, subject_id, session_id=None):
     return next((c for c in candidates if c.exists()), None)
 
 
+def get_version_info(app_version):
+    """Version provenance for the delivered outputs.
+
+    Mirrors the sibling freesurfer-nidm app's version_info block so the two
+    derivatives can be compared. ANTs' version comes from ANTsPy rather than a
+    base image, since that is what actually performs the segmentation.
+    """
+    try:
+        ants_version = ants.__version__
+    except Exception:
+        ants_version = "unknown"
+
+    return {
+        "ants-nidm": {
+            "version": app_version,
+            "source": "setup.py",
+            "timestamp": datetime.now().isoformat(),
+        },
+        "ants": {
+            "version": ants_version,
+            "source": "antspyx",
+        },
+        "python": {
+            "version": sys.version,
+            "packages": {},
+        },
+    }
+
+
+def save_processing_summary(logger, subject_dir, bids_subject, bids_session,
+                            app_version, succeeded, nidm_written):
+    """Write processing_summary.json inside the subject directory.
+
+    BABS zips only sub-<id>/, so anything written outside it is dropped from the
+    delivered derivative -- which is why this goes in the subject dir and not the
+    derivative root. Same file the freesurfer-nidm app ships per subject.
+    """
+    subject_label = f"sub-{bids_subject}"
+    if bids_session:
+        subject_label += f"_ses-{bids_session}"
+
+    summary = {
+        "total": 1,
+        "success": 1 if succeeded else 0,
+        "failure": 0 if succeeded else 1,
+        "skipped": 0,
+        "success_list": [subject_label] if succeeded else [],
+        "failure_list": [] if succeeded else [subject_label],
+        "skipped_list": [],
+        "nidm_written": nidm_written,
+        "version_info": get_version_info(app_version),
+    }
+
+    try:
+        subject_dir = Path(subject_dir)
+        subject_dir.mkdir(parents=True, exist_ok=True)
+        output_path = subject_dir / "processing_summary.json"
+        with open(output_path, "w") as f:
+            json.dump(summary, f, indent=2)
+        logger.info(f"Processing summary saved to {output_path}")
+        return output_path
+    except OSError as e:
+        # Provenance is not worth failing an otherwise-good subject over.
+        logger.warning(f"Could not write processing summary: {e}")
+        return None
+
+
 def create_dataset_description(output_dir, app_version):
     """Create a dataset_description.json file in the output directory."""
     dataset_description = {
@@ -165,8 +236,8 @@ def parse_arguments():
                         type=int, default=1)
     parser.add_argument('-v', '--verbose', help='Verbose output',
                         action='store_true')
-    parser.add_argument('--version', action='version', 
-                        version='ANTs BIDS App v0.1.0')
+    parser.add_argument('--version', action='version',
+                        version=f'ANTs BIDS App v{APP_VERSION}')
     
     args = parser.parse_args()
     
@@ -214,7 +285,7 @@ def initialize(args):
     # the surrounding dataset (BABS/DataLad) rather than by a per-subject job.
     # It is written for standalone runs; under BABS only sub-<id>/ is zipped, so
     # this file is not part of the delivered per-subject unit and cannot collide.
-    create_dataset_description(derivatives_dir, '0.1.0')
+    create_dataset_description(derivatives_dir, APP_VERSION)
 
     # Initialize segmentation with appropriate parameters (only if not skipping ANTs)
     segmenter = None
@@ -404,8 +475,18 @@ def process_participant(args, logger):
             input_file=input_file,
         )
     
+    save_processing_summary(
+        logger=logger,
+        subject_dir=subject_output_dir(derivatives_dir, bids_subject, bids_session),
+        bids_subject=bids_subject,
+        bids_session=bids_session,
+        app_version=APP_VERSION,
+        succeeded=success,
+        nidm_written=(not args.skip_nidm) and success,
+    )
+
     logger.info(f"Participant level analysis complete. Processing {'succeeded' if success else 'failed'}")
-    
+
     return 0 if success else 1
 
 def process_session(args, logger):
@@ -492,8 +573,18 @@ def process_session(args, logger):
             input_file=input_file,
         )
     
+    save_processing_summary(
+        logger=logger,
+        subject_dir=subject_output_dir(derivatives_dir, bids_subject, bids_session),
+        bids_subject=bids_subject,
+        bids_session=bids_session,
+        app_version=APP_VERSION,
+        succeeded=success,
+        nidm_written=(not args.skip_nidm) and success,
+    )
+
     logger.info(f"Session level analysis complete. Processing {'succeeded' if success else 'failed'}")
-    
+
     return 0 if success else 1
 
 

--- a/src/run.py
+++ b/src/run.py
@@ -12,18 +12,15 @@ from datetime import datetime
 import subprocess
 from bids import BIDSLayout
 import ants
-import pkg_resources
 
 # Import local modules
 from src.antspy.wrapper import ANTsSegmentation
 
-def get_bids_version():
-    """Get the version of the installed bids package."""
-    try:
-        return pkg_resources.get_distribution('pybids').version
-    except pkg_resources.DistributionNotFound:
-        # Fallback to a recent stable version if package info not found
-        return "1.8.0"
+# Version of the BIDS *specification* these derivatives claim conformance to.
+# Must never be derived from a library version: pkg_resources.get_distribution
+# ('pybids').version returns pybids' package version (0.16.x), which is not a
+# valid BIDSVersion value.
+BIDS_VERSION = "1.8.0"
 
 def setup_logger(log_dir, verbose=False):
     """Set up logging configuration."""
@@ -43,8 +40,32 @@ def setup_logger(log_dir, verbose=False):
     )
     return logging.getLogger('ants-nidm')
 
+def subject_output_dir(output_dir, bids_subject, bids_session=None):
+    """Per-subject output directory -- the unit BABS zips.
+
+    Returns ``<output_dir>/sub-<id>[/ses-<session>]``. Everything produced for a
+    subject (segmentation, stats, nidm.ttl, ants_cde.ttl) lives here, so the
+    zip's top-level folder is the subject directory and two subjects can never
+    write to the same path.
+
+    Args:
+        output_dir (str or Path): Derivative root
+        bids_subject (str): Subject label without "sub-" prefix
+        bids_session (str, optional): Session label without "ses-" prefix
+    """
+    subject_dir = Path(output_dir) / f"sub-{bids_subject}"
+    if bids_session:
+        subject_dir = subject_dir / f"ses-{bids_session}"
+    return subject_dir
+
+
 def find_nidm_input_file(nidm_input_dir, subject_id, session_id=None):
     """Search for NIDM input file in standard locations.
+
+    Candidates are tried most-specific first. The per-subject ``nidm.ttl``
+    layout comes first because that is what the shared NIDM datasets use
+    (e.g. ``nidm_4.5.0/sub-0051456/nidm.ttl``); the ``sub-<id>.ttl`` and flat
+    forms are kept for older/hand-built inputs.
 
     Args:
         nidm_input_dir (Path): Directory containing NIDM files
@@ -62,41 +83,33 @@ def find_nidm_input_file(nidm_input_dir, subject_id, session_id=None):
     if not nidm_input_dir.exists():
         return None
 
-    # Try subject/session hierarchical structure
+    subject_dirname = f"sub-{subject_id}"
+    candidates = []
+
     if session_id:
-        # With sessions: sub-{id}/ses-{session}/sub-{id}_ses-{session}.ttl
-        hierarchical_path = nidm_input_dir / f"sub-{subject_id}" / f"ses-{session_id}" / f"sub-{subject_id}_ses-{session_id}.ttl"
-        if hierarchical_path.exists():
-            return hierarchical_path
+        candidates += [
+            nidm_input_dir / subject_dirname / f"ses-{session_id}" / "nidm.ttl",
+            nidm_input_dir / f"{subject_dirname}_ses-{session_id}" / "nidm.ttl",
+            nidm_input_dir / subject_dirname / f"ses-{session_id}" / f"{subject_dirname}_ses-{session_id}.ttl",
+            nidm_input_dir / f"{subject_dirname}_ses-{session_id}.ttl",
+        ]
 
-        # Try flat structure with session: sub-{id}_ses-{session}.ttl
-        flat_with_session = nidm_input_dir / f"sub-{subject_id}_ses-{session_id}.ttl"
-        if flat_with_session.exists():
-            return flat_with_session
-    else:
-        # Without sessions: sub-{id}/sub-{id}.ttl
-        hierarchical_path = nidm_input_dir / f"sub-{subject_id}" / f"sub-{subject_id}.ttl"
-        if hierarchical_path.exists():
-            return hierarchical_path
+    candidates += [
+        nidm_input_dir / subject_dirname / "nidm.ttl",
+        nidm_input_dir / subject_dirname / f"{subject_dirname}.ttl",
+        nidm_input_dir / f"{subject_dirname}.ttl",
+        # Dataset-level fallback: a single NIDM file covering all subjects.
+        nidm_input_dir / "nidm.ttl",
+    ]
 
-        # Try flat structure without session: sub-{id}.ttl
-        flat_without_session = nidm_input_dir / f"sub-{subject_id}.ttl"
-        if flat_without_session.exists():
-            return flat_without_session
-
-    # Fallback to generic nidm.ttl at directory root
-    fallback_path = nidm_input_dir / "nidm.ttl"
-    if fallback_path.exists():
-        return fallback_path
-
-    return None
+    return next((c for c in candidates if c.exists()), None)
 
 
 def create_dataset_description(output_dir, app_version):
     """Create a dataset_description.json file in the output directory."""
     dataset_description = {
         "Name": "ANTs segmentation derivatives",
-        "BIDSVersion": get_bids_version(),
+        "BIDSVersion": BIDS_VERSION,
         "DatasetType": "derivative",
         "GeneratedBy": [
             {
@@ -168,7 +181,7 @@ def initialize(args):
     Args:
         args: Command line arguments
     Returns:
-        tuple: (layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir)
+        tuple: (layout, segmenter, derivatives_dir, nidm_input_dir)
     """
     # Normalize incoming paths from argparse to Path objects
     args.bids_dir = Path(args.bids_dir)
@@ -186,20 +199,21 @@ def initialize(args):
 
     if not nidm_input_dir.exists():
         nidm_input_dir = None
-        
-    # Create output directory
-    args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create ants-nidm_bidsapp directory for all outputs
-    ants_nidm_bidsapp_dir = args.output_dir / 'ants-nidm_bidsapp'
-    ants_nidm_bidsapp_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create the output derivative directory with BIDS-compliant structure
-    # Outputs go to output_dir/ants-nidm_bidsapp/ants-seg/ and output_dir/ants-nidm_bidsapp/nidm/
-    derivatives_dir = ants_nidm_bidsapp_dir / 'ants-seg'
+    # Per-subject output layout (study-wide standard): everything this app
+    # produces for a subject lives under <output_dir>/sub-<id>/, so the BABS
+    # zip's top-level folder is the subject directory and results land as
+    # <derivative_name>/sub-<id>/... when unzipped. There is deliberately no
+    # app-name wrapper directory and no shared nidm/ directory: a shared
+    # nidm/nidm.ttl made every subject's NIDM collide on one path, and
+    # `unzip -n` at merge time silently kept only the first subject's copy.
+    derivatives_dir = args.output_dir
     derivatives_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create dataset_description.json
+    # dataset_description.json describes the derivative root, which is owned by
+    # the surrounding dataset (BABS/DataLad) rather than by a per-subject job.
+    # It is written for standalone runs; under BABS only sub-<id>/ is zipped, so
+    # this file is not part of the delivered per-subject unit and cannot collide.
     create_dataset_description(derivatives_dir, '0.1.0')
 
     # Initialize segmentation with appropriate parameters (only if not skipping ANTs)
@@ -214,20 +228,23 @@ def initialize(args):
             verbose=args.verbose
         )
 
-    # Create NIDM output directory under ants-nidm_bidsapp
-    nidm_dir = ants_nidm_bidsapp_dir / 'nidm'
-    nidm_dir.mkdir(parents=True, exist_ok=True)
+    return layout, segmenter, derivatives_dir, nidm_input_dir
 
-    return layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir
-
-def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_file=None, bids_session=None, verbose=False, input_file=None):
+def nidm_conversion(logger, derivatives_dir, bids_subject, nidm_input_file=None,
+                    bids_session=None, verbose=False, input_file=None):
     """Convert ANTs segmentation outputs to NIDM format.
+
+    Writes ``nidm.ttl`` (and the shared ``ants_cde.ttl`` vocabulary, which
+    ants_seg_to_nidm serializes next to the -o target) into the subject's own
+    output directory, alongside the segmentation results. The output is always
+    named ``nidm.ttl`` -- subject identity is carried by the directory, which is
+    also what keeps concurrent subjects from colliding.
+
     Args:
         logger: Logger instance
-        derivatives_dir (str or Path): Path to ANTs derivatives directory
-        nidm_dir (str or Path): Path to NIDM output directory
+        derivatives_dir (str or Path): Derivative root (output_dir)
         bids_subject (str): Subject label (without "sub-" prefix)
-        nidm_input_file (Path or None): Optional existing NIDM TTL file to update
+        nidm_input_file (Path or None): Optional existing NIDM TTL file to append to
         bids_session (str): Session label (without "ses-" prefix)
         verbose (bool): Enable verbose output
         input_file (str or Path): Path to the input T1w file
@@ -235,69 +252,51 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
         bool: True if conversion succeeded, False otherwise
     """
     log_prefix = f"subject {bids_subject}" + (f", session {bids_session}" if bids_session else "")
-    
-    try:
-        # Convert paths to Path objects
-        derivatives_dir = Path(derivatives_dir)
-        nidm_dir = Path(nidm_dir)
-        nidm_dir.mkdir(parents=True, exist_ok=True)
 
-        # Check for existing NIDM file
+    try:
+        derivatives_dir = Path(derivatives_dir)
+        subject_dir = subject_output_dir(derivatives_dir, bids_subject, bids_session)
+        subject_dir.mkdir(parents=True, exist_ok=True)
+
+        # Existing NIDM file to append to. Always the pristine input -- never a
+        # nidm.ttl left in the output directory by an earlier attempt, which
+        # would double-add this subject's measurements on a retry.
         existing_nidm_file = None
-        if nidm_input_file:
-            # Check if a previous run already created output in nidm_dir
-            copied_nidm_file = nidm_dir / nidm_input_file.name
-            if copied_nidm_file.exists():
-                existing_nidm_file = copied_nidm_file
-            elif nidm_input_file.exists():
-                # Use the original input file found by find_nidm_input_file()
-                existing_nidm_file = nidm_input_file
-        
-        # Define paths to segmentation outputs
-        # Files are under sub-*/[ses-*/]anat/ and sub-*/[ses-*/]stats/ for BIDS compliance
+        if nidm_input_file and Path(nidm_input_file).exists():
+            existing_nidm_file = Path(nidm_input_file)
+
+        # Segmentation outputs live under sub-*/[ses-*/]{anat,stats}/
         seg_base = f"sub-{bids_subject}"
         if bids_session:
             seg_base += f"_ses-{bids_session}"
-
-        # Build subject/session directory path
-        subject_dir = derivatives_dir / f"sub-{bids_subject}"
-        if bids_session:
-            subject_dir = subject_dir / f"ses-{bids_session}"
 
         anat_dir = subject_dir / "anat"
         stats_dir = subject_dir / "stats"
 
         seg_path = anat_dir / f"{seg_base}_space-orig_dseg.nii.gz"
-
-        # Construct NIDM output filename (flat structure, TTL format)
-        nidm_base = seg_base
-        nidm_file = nidm_dir / f"{nidm_base}.ttl"
-
-        # Define paths to the statistics files (with subject prefix)
         label_stats = stats_dir / f"{seg_base}_antslabelstats.csv"
         brain_vols = stats_dir / f"{seg_base}_antsbrainvols.csv"
-        
+
         # Check if required files exist
         required_files = [seg_path, label_stats, brain_vols]
         for file_path in required_files:
             if not file_path.exists():
                 logger.error(f"Required file not found: {file_path}")
                 return False
-        
-        # If adding to existing NIDM file, output should be combined nidm.ttl
-        # Otherwise, output is subject-specific TTL file
-        if existing_nidm_file:
-            nidm_output = nidm_dir / "nidm.ttl"
-        else:
-            nidm_output = nidm_file
-        
-        # Convert all paths to strings for subprocess call
+
+        # The product is always <subject_dir>/nidm.ttl, whether or not there was
+        # an input NIDM file to augment.
+        nidm_output = subject_dir / "nidm.ttl"
+
         label_stats_str = str(label_stats.absolute())
         brain_vols_str = str(brain_vols.absolute())
         seg_path_str = str(seg_path.absolute())
         nidm_output_str = str(nidm_output.absolute())
-        
-        # Construct the command to run ants_seg_to_nidm.py
+
+        # Construct the command to run ants_seg_to_nidm.py.
+        # NOTE: -subjid is the participant identifier used to match/attach the
+        # subject inside the NIDM graph; ants_seg_to_nidm has no -session
+        # option, so session identity is carried by the output directory.
         cmd = [
             "python", "-m",
             "ants_seg_to_nidm.ants_seg_to_nidm",
@@ -306,39 +305,37 @@ def nidm_conversion(logger, derivatives_dir, nidm_dir, bids_subject, nidm_input_
             "-o", nidm_output_str
         ]
 
-        # Add session if available
-        if bids_session:
-            cmd.extend(["-session", f"ses-{bids_session}"])
-
-        # Add JSON-LD flag if output format is JSON-LD
-        if nidm_output_str.endswith('.json-ld'):
-            cmd.append("-j")
-
-        logger.info(f"Converting segmentation to NIDM for {log_prefix}")
-        logger.info(f"Running command: {' '.join(cmd)}")
-        
         # Add existing NIDM file if available
         if existing_nidm_file:
             cmd.extend(["--nidm", str(existing_nidm_file.absolute()), "--forcenidm"])
-            logger.info(f"Adding data to existing NIDM file: {existing_nidm_file}")
-            logger.info(f"Combined NIDM will be written to: {nidm_output_str}")
 
-        # Run the command from the script's directory
+        logger.info(f"Converting segmentation to NIDM for {log_prefix}")
+        if existing_nidm_file:
+            logger.info(f"Adding data to existing NIDM file: {existing_nidm_file}")
+        logger.info(f"NIDM will be written to: {nidm_output_str}")
+        logger.info(f"Running command: {' '.join(cmd)}")
+
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
         )
-        
+
         if result.returncode != 0:
             logger.error(f"Error in NIDM conversion: {result.stderr}")
             return False
-        else:
-            logger.info(f"NIDM conversion complete for {log_prefix}")
-            if verbose:
-                logger.debug(f"NIDM conversion output: {result.stdout}")
-            return True
-            
+
+        if not nidm_output.exists():
+            logger.error(f"NIDM conversion reported success but {nidm_output} was not written")
+            return False
+
+        logger.info(f"NIDM conversion complete for {log_prefix}")
+        for produced in sorted(subject_dir.glob("*.ttl")):
+            logger.info(f"  - {produced.name} ({produced.stat().st_size} bytes)")
+        if verbose:
+            logger.debug(f"NIDM conversion output: {result.stdout}")
+        return True
+
     except Exception as e:
         logger.error(f"Error in NIDM conversion for {log_prefix}: {str(e)}")
         return False
@@ -348,7 +345,7 @@ def process_participant(args, logger):
     logger.info("Starting participant level analysis (single-session dataset)")
 
     # Initialize app
-    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir = initialize(args)
+    layout, segmenter, derivatives_dir, nidm_input_dir = initialize(args)
     
     # Get subject to process
     available_subjects = layout.get_subjects()
@@ -400,7 +397,6 @@ def process_participant(args, logger):
         success = nidm_conversion(
             logger=logger,
             derivatives_dir=derivatives_dir,
-            nidm_dir=nidm_dir,
             bids_subject=bids_subject,
             nidm_input_file=nidm_input_file,
             bids_session=bids_session,
@@ -421,7 +417,7 @@ def process_session(args, logger):
     logger.info("Starting session level analysis (multi-session dataset)")
 
     # Initialize app
-    layout, segmenter, derivatives_dir, nidm_dir, nidm_input_dir = initialize(args)
+    layout, segmenter, derivatives_dir, nidm_input_dir = initialize(args)
     
     # Get subject to process
     available_subjects = layout.get_subjects()
@@ -489,7 +485,6 @@ def process_session(args, logger):
         success = nidm_conversion(
             logger=logger,
             derivatives_dir=derivatives_dir,
-            nidm_dir=nidm_dir,
             bids_subject=bids_subject,
             nidm_input_file=nidm_input_file,
             bids_session=bids_session,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -79,7 +79,8 @@ sys.modules['bids'] = mock_bids
 # Import after mocking
 from src.run import (process_participant, process_session, main, nidm_conversion,
                      create_dataset_description, subject_output_dir,
-                     find_nidm_input_file, BIDS_VERSION)
+                     find_nidm_input_file, save_processing_summary,
+                     BIDS_VERSION, APP_VERSION)
 
 class TestRun(unittest.TestCase):
     """Test cases for the run module"""
@@ -486,6 +487,44 @@ class TestRun(unittest.TestCase):
             desc = json.load(f)
             self.assertEqual(desc["BIDSVersion"], BIDS_VERSION)
             self.assertEqual(desc["GeneratedBy"][0]["Version"], "1.0.0")
+
+    def test_processing_summary_lands_inside_subject_dir(self):
+        """BABS zips only sub-<id>/, so the summary must be written inside it."""
+        subject_dir = subject_output_dir(self.output_dir, "01")
+        path = save_processing_summary(
+            logger=self.logger,
+            subject_dir=subject_dir,
+            bids_subject="01",
+            bids_session=None,
+            app_version=APP_VERSION,
+            succeeded=True,
+            nidm_written=True,
+        )
+        self.assertEqual(path, subject_dir / "processing_summary.json")
+        with open(path) as f:
+            summary = json.load(f)
+        self.assertEqual(summary["success"], 1)
+        self.assertEqual(summary["failure"], 0)
+        self.assertEqual(summary["success_list"], ["sub-01"])
+        self.assertEqual(summary["version_info"]["ants-nidm"]["version"], APP_VERSION)
+        self.assertIn("ants", summary["version_info"])
+
+    def test_processing_summary_records_failure(self):
+        """A failed subject is recorded as such, with the session in its label."""
+        subject_dir = subject_output_dir(self.output_dir, "01", "baseline")
+        path = save_processing_summary(
+            logger=self.logger,
+            subject_dir=subject_dir,
+            bids_subject="01",
+            bids_session="baseline",
+            app_version=APP_VERSION,
+            succeeded=False,
+            nidm_written=False,
+        )
+        with open(path) as f:
+            summary = json.load(f)
+        self.assertEqual(summary["failure_list"], ["sub-01_ses-baseline"])
+        self.assertFalse(summary["nidm_written"])
 
     def test_subject_output_dir(self):
         """Per-subject output dir is the zip unit: no app wrapper, no nidm/."""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -9,14 +9,6 @@ from pathlib import Path
 import json
 import numpy as np
 
-# Handle pkg_resources import (deprecated in Python 3.12+)
-try:
-    import pkg_resources
-except ModuleNotFoundError:
-    # Create a mock pkg_resources for testing purposes
-    pkg_resources = MagicMock()
-    pkg_resources.DistributionNotFound = type('DistributionNotFound', (Exception,), {})
-
 # Add the project root to the Python path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_root)
@@ -83,10 +75,11 @@ sys.modules['ants'] = mock_ants
 sys.modules['numpy'] = np
 sys.modules['nibabel'] = MagicMock()
 sys.modules['bids'] = mock_bids
-sys.modules['pkg_resources'] = pkg_resources
 
 # Import after mocking
-from src.run import process_participant, process_session, main, nidm_conversion, get_bids_version, create_dataset_description
+from src.run import (process_participant, process_session, main, nidm_conversion,
+                     create_dataset_description, subject_output_dir,
+                     find_nidm_input_file, BIDS_VERSION)
 
 class TestRun(unittest.TestCase):
     """Test cases for the run module"""
@@ -125,9 +118,12 @@ class TestRun(unittest.TestCase):
             f.write("dummy data")
 
     def create_derivatives_structure(self):
-        """Create a minimal derivatives structure for testing NIDM conversion"""
-        derivatives_dir = os.path.join(self.output_dir, "ants-nidm_bidsapp", "ants-seg")
-        # Create BIDS-compliant sub-*/ses-* directory structure
+        """Create a minimal derivatives structure for testing NIDM conversion.
+
+        Per-subject layout: the derivative root *is* output_dir, and everything
+        for a subject lives under output_dir/sub-<id>/[ses-<x>/].
+        """
+        derivatives_dir = self.output_dir
         subject_dir = os.path.join(derivatives_dir, "sub-01", "ses-01")
         anat_dir = os.path.join(subject_dir, "anat")
         stats_dir = os.path.join(subject_dir, "stats")
@@ -156,8 +152,7 @@ class TestRun(unittest.TestCase):
         """Test NIDM conversion with proper file structure"""
         # Create derivatives structure
         derivatives_dir = self.create_derivatives_structure()
-        nidm_dir = os.path.join(self.output_dir, "ants-nidm_bidsapp", "nidm")
-        os.makedirs(nidm_dir, exist_ok=True)
+        subject_dir = os.path.join(derivatives_dir, "sub-01", "ses-01")
         
         # Run NIDM conversion
         with patch('subprocess.run') as mock_run:
@@ -168,18 +163,25 @@ class TestRun(unittest.TestCase):
             mock_process.stderr = ""
             mock_run.return_value = mock_process
             
+            # subprocess is mocked, so create the file the real converter would
+            def write_nidm(*a, **kw):
+                with open(os.path.join(subject_dir, "nidm.ttl"), "w") as f:
+                    f.write("@prefix nidm: <http://purl.org/nidash/nidm#> .\n")
+                return mock_process
+            mock_run.side_effect = write_nidm
+
             result = nidm_conversion(
                 self.logger,
                 derivatives_dir,
-                nidm_dir,
                 "01",
                 bids_session="01",  # Pass session to match test file structure
                 verbose=True
             )
-            
+
             # Check results
             self.assertTrue(result)
-            self.assertTrue(os.path.exists(nidm_dir))
+            # NIDM lands in the subject's own directory, named nidm.ttl
+            self.assertTrue(os.path.exists(os.path.join(subject_dir, "nidm.ttl")))
             
             # Verify subprocess call
             mock_run.assert_called_once()
@@ -193,6 +195,11 @@ class TestRun(unittest.TestCase):
             self.assertIn("-subjid", cmd_args)
             # TTL format is default, so -j flag should NOT be present
             self.assertNotIn("-j", cmd_args)
+            # ants_seg_to_nidm has no -session option; passing it would abort
+            self.assertNotIn("-session", cmd_args)
+            # Output is the per-subject nidm.ttl
+            self.assertEqual(cmd_args[cmd_args.index("-o") + 1],
+                             os.path.abspath(os.path.join(subject_dir, "nidm.ttl")))
             
             # Verify file paths exist
             paths_str = [arg for arg in cmd_args if ".csv" in arg or ".nii.gz" in arg][0]
@@ -203,14 +210,11 @@ class TestRun(unittest.TestCase):
 
     def test_nidm_conversion_missing_files(self):
         """Test NIDM conversion with missing required files"""
-        derivatives_dir = os.path.join(self.output_dir, "ants-nidm_bidsapp", "ants-seg")
-        nidm_dir = os.path.join(self.output_dir, "ants-nidm_bidsapp", "nidm")
-        os.makedirs(derivatives_dir)
-        
+        derivatives_dir = self.output_dir
+
         result = nidm_conversion(
             self.logger,
             derivatives_dir,
-            nidm_dir,
             "01",
             verbose=True
         )
@@ -296,7 +300,7 @@ class TestRun(unittest.TestCase):
                 # subject_id comes in as "sub-01", extract the label
                 bids_subject = subject_id.replace('sub-', '') if subject_id.startswith('sub-') else subject_id
                 seg_base = f"sub-{bids_subject}"
-                subject_dir = os.path.join(self.output_dir, 'ants-nidm_bidsapp', 'ants-seg', f'sub-{bids_subject}')
+                subject_dir = os.path.join(self.output_dir, f'sub-{bids_subject}')
                 if session_label:
                     subject_dir = os.path.join(subject_dir, f'ses-{session_label}')
                     seg_base += f"_ses-{session_label}"
@@ -418,7 +422,7 @@ class TestRun(unittest.TestCase):
                 # subject_id comes in as "sub-01", session_label as "ses-01"
                 bids_subject = subject_id.replace('sub-', '') if subject_id.startswith('sub-') else subject_id
                 seg_base = f"sub-{bids_subject}"
-                subject_dir = os.path.join(self.output_dir, 'ants-nidm_bidsapp', 'ants-seg', f'sub-{bids_subject}')
+                subject_dir = os.path.join(self.output_dir, f'sub-{bids_subject}')
                 if session_label:
                     bids_session = session_label.replace('ses-', '') if session_label.startswith('ses-') else session_label
                     subject_dir = os.path.join(subject_dir, f'ses-{bids_session}')
@@ -455,39 +459,64 @@ class TestRun(unittest.TestCase):
             mock_instance.run_subject.assert_called_once_with("sub-01", "ses-01", method="quick")
             mock_nidm.assert_called_once()
 
-    def test_get_bids_version(self):
-        """Test getting BIDS version from package"""
-        # Test with mock package
-        with patch('pkg_resources.get_distribution') as mock_dist:
-            mock_dist.return_value = MagicMock(version="0.1.0")
-            version = get_bids_version()
-            self.assertEqual(version, "0.1.0")
-            
-        # Test fallback when package not found
-        with patch('pkg_resources.get_distribution') as mock_dist:
-            mock_dist.side_effect = pkg_resources.DistributionNotFound()
-            version = get_bids_version()
-            self.assertEqual(version, "1.8.0")
-    
+    def test_bids_version_is_a_spec_version(self):
+        """BIDSVersion must be a BIDS *spec* version, not a library version.
+
+        pybids' package version is 0.x; if BIDS_VERSION ever gets sourced from a
+        library again this catches it.
+        """
+        major, minor = BIDS_VERSION.split(".")[:2]
+        self.assertGreaterEqual(int(major), 1,
+                                f"BIDS_VERSION {BIDS_VERSION!r} looks like a package version")
+        self.assertTrue(minor.isdigit())
+
     def test_create_dataset_description(self):
         """Test creation of dataset_description.json"""
         test_dir = os.path.join(self.temp_dir, "test_desc")
         os.makedirs(test_dir)
-        
-        # Test with mock version
-        with patch('src.run.get_bids_version') as mock_version:
-            mock_version.return_value = "0.1.0"
-            create_dataset_description(test_dir, "1.0.0")
-            
-            # Check if file exists
-            desc_file = os.path.join(test_dir, "dataset_description.json")
-            self.assertTrue(os.path.exists(desc_file))
-            
-            # Check content
-            with open(desc_file) as f:
-                desc = json.load(f)
-                self.assertEqual(desc["BIDSVersion"], "0.1.0")
-                self.assertEqual(desc["GeneratedBy"][0]["Version"], "1.0.0")
+
+        create_dataset_description(test_dir, "1.0.0")
+
+        # Check if file exists
+        desc_file = os.path.join(test_dir, "dataset_description.json")
+        self.assertTrue(os.path.exists(desc_file))
+
+        # Check content
+        with open(desc_file) as f:
+            desc = json.load(f)
+            self.assertEqual(desc["BIDSVersion"], BIDS_VERSION)
+            self.assertEqual(desc["GeneratedBy"][0]["Version"], "1.0.0")
+
+    def test_subject_output_dir(self):
+        """Per-subject output dir is the zip unit: no app wrapper, no nidm/."""
+        self.assertEqual(str(subject_output_dir("/out", "01")), "/out/sub-01")
+        self.assertEqual(str(subject_output_dir("/out", "01", "baseline")),
+                         "/out/sub-01/ses-baseline")
+
+    def test_no_cross_subject_nidm_collision(self):
+        """Two subjects must never resolve to the same NIDM output path."""
+        a = subject_output_dir(self.output_dir, "01") / "nidm.ttl"
+        b = subject_output_dir(self.output_dir, "02") / "nidm.ttl"
+        self.assertNotEqual(a, b)
+
+    def test_find_nidm_input_file_per_subject_nidm_ttl(self):
+        """sub-<id>/nidm.ttl is the layout the shared NIDM datasets use."""
+        nidm_in = Path(self.temp_dir) / "NIDM"
+        (nidm_in / "sub-01").mkdir(parents=True)
+        target = nidm_in / "sub-01" / "nidm.ttl"
+        target.write_text("")
+        (nidm_in / "nidm.ttl").write_text("")  # dataset-level fallback
+
+        # Per-subject file wins over the dataset-level fallback
+        self.assertEqual(find_nidm_input_file(nidm_in, "01"), target)
+        # Unknown subject falls back to the dataset-level file
+        self.assertEqual(find_nidm_input_file(nidm_in, "99"), nidm_in / "nidm.ttl")
+        # Session-nested form
+        sess = nidm_in / "sub-02" / "ses-baseline"
+        sess.mkdir(parents=True)
+        (sess / "nidm.ttl").write_text("")
+        self.assertEqual(find_nidm_input_file(nidm_in, "02", "baseline"),
+                         sess / "nidm.ttl")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -195,11 +195,11 @@ class TestANTsSegmentation(unittest.TestCase):
                     f"no probseg written for label {label_id}: {written}")
 
     def test_cortical_thickness_uses_invtransforms_for_template_to_subject(self):
-        """The extraction mask must come template -> subject, i.e. invtransforms.
+        """The final brain mask must come template -> subject, i.e. invtransforms.
 
         Regression test. compute_cortical_thickness registers subject -> template
         (fixed=brain_template, moving=brain_image), so fwdtransforms maps
-        subject -> template. Pulling the template-space extraction mask into
+        subject -> template. Pulling the template-space brain mask into
         subject space with fwdtransforms produced a mask covering the whole FOV,
         so joint label fusion labelled air, skull and neck -- 100% of voxels
         labelled, no background, and an 11.5 L brain volume on ABIDE sub-0051456.
@@ -243,6 +243,95 @@ class TestANTsSegmentation(unittest.TestCase):
 
         # The stored template->subject transforms are the same ordered list
         self.assertEqual(results["TemplateToSubjectTransforms"], INV)
+
+    def _run_cortical_thickness_recording_calls(self):
+        """Run compute_cortical_thickness with mocks that tag every image read
+        with its source path and record all registration/apply_transforms calls.
+
+        Returns (registrations, applied, results).
+        """
+        def fake_image_read(path, *args, **kwargs):
+            img = mock_image_read()
+            img.src_path = str(path)
+            return img
+
+        registrations = []
+
+        def fake_registration(*args, **kwargs):
+            registrations.append(kwargs)
+            return {
+                "fwdtransforms": ["/fake/1Warp.nii.gz", "/fake/0GenericAffine.mat"],
+                "invtransforms": ["/fake/0GenericAffine.mat", "/fake/1InverseWarp.nii.gz"],
+                "warpedmovout": mock_image_read(),
+            }
+
+        applied = []
+
+        def fake_apply_transforms(*args, **kwargs):
+            applied.append(kwargs)
+            out = mock_image_read()
+            # Propagate the source tag so assertions can trace warped images
+            moving = kwargs.get("moving")
+            out.src_path = getattr(moving, "src_path", None)
+            return out
+
+        def fake_imath(img, *args, **kwargs):
+            return img
+
+        def fake_threshold(img, *args, **kwargs):
+            out = mock_image_read()
+            out.src_path = getattr(img, "src_path", None)
+            return out
+
+        with patch('src.antspy.wrapper.ants.image_read', side_effect=fake_image_read), \
+             patch('src.antspy.wrapper.ants.n4_bias_field_correction', side_effect=lambda img, **k: mock_image_read()), \
+             patch('src.antspy.wrapper.ants.registration', side_effect=fake_registration), \
+             patch('src.antspy.wrapper.ants.apply_transforms', side_effect=fake_apply_transforms), \
+             patch('src.antspy.wrapper.ants.threshold_image', side_effect=fake_threshold), \
+             patch('src.antspy.wrapper.ants.iMath', side_effect=fake_imath):
+            results = self.segmenter.compute_cortical_thickness(mock_image_read())
+
+        return registrations, applied, results
+
+    def test_final_brain_mask_derived_from_probability_mask(self):
+        """The final brain mask must come from the brain probability mask.
+
+        Regression test. T_template0_BrainCerebellumExtractionMask is the
+        generous registration-scope mask of the OASIS-30 kit (5.9 L in template
+        space -- antsBrainExtraction.sh's -f argument), not a brain mask. Using
+        it as the final mask labelled ~5.6 L of head on ABIDE sub-0051456. The
+        brain mask is the warped ProbabilityMask thresholded at 0.5 (1.34 L).
+        """
+        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+
+        self.assertGreaterEqual(len(applied), 2)
+        final_mask_src = applied[-1]["moving"].src_path
+        self.assertIn(
+            "ProbabilityMask", final_mask_src,
+            f"final brain mask must be warped from the ProbabilityMask, got {final_mask_src}")
+        self.assertNotIn(
+            "ExtractionMask", final_mask_src,
+            "ExtractionMask is a registration-scope mask (5.9 L), not a brain mask")
+        self.assertIn(
+            "ProbabilityMask", results["BrainExtractionMask"].src_path,
+            "returned BrainExtractionMask must trace back to the ProbabilityMask")
+
+    def test_template_registration_targets_brain_only_template(self):
+        """Affine/SyN registration must target the brain-only template.
+
+        The subject image is skull-stripped before this registration, so the
+        fixed image must be T_template0_BrainCerebellum. Registering a
+        brain-only image onto the whole-head T_template0 biases the affine to
+        scale the brain toward the head outline, inflating the warped mask.
+        """
+        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+
+        self.assertGreaterEqual(len(registrations), 2)
+        for i, reg in enumerate(registrations):
+            fixed_src = reg["fixed"].src_path
+            self.assertIn(
+                "BrainCerebellum", fixed_src,
+                f"registration #{i} must target the brain-only template, got {fixed_src}")
 
     def test_organize_bids_output_with_session(self):
         """Test organizing outputs in BIDS format with session"""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -133,9 +133,12 @@ class TestANTsSegmentation(unittest.TestCase):
         mock_prob3.numpy.return_value = np.array([0.1, 0.1, 0.1, 0.8, 0.8, 0.8])
         mock_prob3.spacing = [1.0, 1.0, 1.0]
 
+        # 'fusion' returns one posterior per anatomical label, plus the label
+        # numbers those posteriors belong to.
         segmentation_results = {
             'segmentation': mock_seg,
-            'probabilityimages': [mock_prob1, mock_prob2, mock_prob3]
+            'probabilityimages': [mock_prob1, mock_prob2, mock_prob3],
+            'segmentation_numbers': [1, 2, 24],
         }
 
         with patch('src.antspy.wrapper.ants.image_write') as mock_write:
@@ -167,21 +170,79 @@ class TestANTsSegmentation(unittest.TestCase):
                 self.assertEqual(volumes["1"], 2)
                 self.assertEqual(volumes["2"], 3)
 
-            # Verify brainvols.csv content
+            # Verify brainvols.csv content. BVOL only: CSFVOL/GMVOL/WMVOL used to
+            # be derived from probabilityimages[0..2] as if they were CSF/GM/WM
+            # tissue posteriors, but under 'fusion' those are per-label
+            # posteriors and under 'quick' they do not exist -- so the columns
+            # were wrong in every path that produced them.
             with open(brainvols_file, newline='') as f:
                 reader = csv.DictReader(f)
-                fieldnames = reader.fieldnames or []
-                self.assertTrue({"BVOL", "CSFVOL", "GMVOL", "WMVOL"}.issubset(set(fieldnames)))
+                fieldnames = set(reader.fieldnames or [])
+                self.assertEqual(fieldnames, {"BVOL"})
+                self.assertFalse(fieldnames & {"CSFVOL", "GMVOL", "WMVOL"},
+                                 "tissue volumes must not be faked from label posteriors")
                 rows = list(reader)
                 self.assertEqual(len(rows), 1)
-                row = rows[0]
-                self.assertIn("BVOL", row)
-                self.assertIn("CSFVOL", row)
-                self.assertIn("GMVOL", row)
-                self.assertIn("WMVOL", row)
 
             # Check that image_write was called for all images
             self.assertEqual(mock_write.call_count, 4)  # 1 segmentation + 3 probability maps
+
+            # Probability maps are named by anatomical label, not list position
+            written = [str(call.args[1]) for call in mock_write.call_args_list]
+            for label_id in (1, 2, 24):
+                self.assertTrue(
+                    any(f"label-{label_id}_probseg" in w for w in written),
+                    f"no probseg written for label {label_id}: {written}")
+
+    def test_cortical_thickness_uses_invtransforms_for_template_to_subject(self):
+        """The extraction mask must come template -> subject, i.e. invtransforms.
+
+        Regression test. compute_cortical_thickness registers subject -> template
+        (fixed=brain_template, moving=brain_image), so fwdtransforms maps
+        subject -> template. Pulling the template-space extraction mask into
+        subject space with fwdtransforms produced a mask covering the whole FOV,
+        so joint label fusion labelled air, skull and neck -- 100% of voxels
+        labelled, no background, and an 11.5 L brain volume on ABIDE sub-0051456.
+        """
+        FWD = ["/fake/subj_to_tmpl_1Warp.nii.gz", "/fake/subj_to_tmpl_0GenericAffine.mat"]
+        INV = ["/fake/subj_to_tmpl_0GenericAffine.mat", "/fake/subj_to_tmpl_1InverseWarp.nii.gz"]
+
+        def fake_registration(*args, **kwargs):
+            return {
+                "fwdtransforms": list(FWD),
+                "invtransforms": list(INV),
+                "warpedmovout": mock_image_read(),
+            }
+
+        applied = []
+
+        def fake_apply_transforms(*args, **kwargs):
+            applied.append(kwargs)
+            return mock_image_read()
+
+        # Patch the name the module under test resolves, not this file's mock
+        # object: tests/test_run.py also assigns sys.modules['ants'], so which
+        # mock src.antspy.wrapper.ants points at depends on import order.
+        with patch('src.antspy.wrapper.ants.registration', side_effect=fake_registration), \
+             patch('src.antspy.wrapper.ants.apply_transforms', side_effect=fake_apply_transforms), \
+             patch('src.antspy.wrapper.ants.threshold_image', side_effect=lambda *a, **k: mock_image_read()), \
+             patch('src.antspy.wrapper.ants.iMath', side_effect=lambda img, *a, **k: img):
+            results = self.segmenter.compute_cortical_thickness(mock_image_read())
+
+        # Last apply_transforms call is the extraction mask -> subject space
+        self.assertGreaterEqual(len(applied), 1)
+        mask_call = applied[-1]
+        self.assertEqual(
+            mask_call["transformlist"], INV,
+            "extraction mask must be warped with invtransforms (template -> subject)")
+        self.assertNotEqual(
+            mask_call["transformlist"], FWD,
+            "using fwdtransforms warps the mask the wrong way and yields a full-FOV mask")
+        # whichtoinvert must stay unset so ANTsPy infers (True, False) itself
+        self.assertIsNone(mask_call.get("whichtoinvert"))
+
+        # The stored template->subject transforms are the same ordered list
+        self.assertEqual(results["TemplateToSubjectTransforms"], INV)
 
     def test_organize_bids_output_with_session(self):
         """Test organizing outputs in BIDS format with session"""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -316,18 +316,48 @@ class TestANTsSegmentation(unittest.TestCase):
             "ProbabilityMask", results["BrainExtractionMask"].src_path,
             "returned BrainExtractionMask must trace back to the ProbabilityMask")
 
-    def test_template_registration_targets_brain_only_template(self):
-        """Affine/SyN registration must target the brain-only template.
+    def test_initial_registration_is_head_to_head_with_extraction_metric_mask(self):
+        """The initial registration must match like content with like.
 
-        The subject image is skull-stripped before this registration, so the
+        Regression test. The old init registered the whole-head subject image
+        onto the brain-only BrainCerebellum template with a rigid-only
+        transform and no metric mask. That problem is bistable across CPU
+        types: identical code and input produced a 1.70 L mask on node1406,
+        2.84 L on node2906 and 3.25 L on node2000. Canonical
+        antsBrainExtraction.sh semantics instead: register whole-head to the
+        whole-head T_template0, restrict the metric with the ExtractionMask
+        (that file's actual job), and use an affine so head size differences
+        are absorbed by scaling, not by the mask.
+        """
+        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+
+        self.assertGreaterEqual(len(registrations), 2)
+        init = registrations[0]
+        fixed_src = init["fixed"].src_path
+        self.assertTrue(
+            fixed_src.endswith("T_template0.nii.gz"),
+            f"init registration must target the whole-head template, got {fixed_src}")
+        self.assertIn(
+            "Affine", init.get("type_of_transform", ""),
+            "init registration needs scaling (affine), rigid cannot absorb head size")
+        mask = init.get("mask")
+        self.assertIsNotNone(mask, "init registration must restrict its metric with a mask")
+        self.assertIn(
+            "ExtractionMask", mask.src_path,
+            f"the metric mask must be the ExtractionMask, got {mask.src_path}")
+
+    def test_refinement_registrations_target_brain_only_template(self):
+        """Affine/SyN refinement must target the brain-only template.
+
+        The subject image is skull-stripped before these registrations, so the
         fixed image must be T_template0_BrainCerebellum. Registering a
         brain-only image onto the whole-head T_template0 biases the affine to
         scale the brain toward the head outline, inflating the warped mask.
         """
         registrations, applied, results = self._run_cortical_thickness_recording_calls()
 
-        self.assertGreaterEqual(len(registrations), 2)
-        for i, reg in enumerate(registrations):
+        self.assertGreaterEqual(len(registrations), 3)
+        for i, reg in enumerate(registrations[1:], start=1):
             fixed_src = reg["fixed"].src_path
             self.assertIn(
                 "BrainCerebellum", fixed_src,


### PR DESCRIPTION
Closes #9. Closes #10.

Works through issue #10's hardening checklist, then fixes six further defects that only surfaced once the app was actually executed on real data for the first time.

## Issue #10 checklist

| item | verdict |
|---|---|
| 1. `BIDSVersion` from a library version | fixed — `BIDS_VERSION = "1.8.0"` constant + a test that rejects a `0.x`-shaped value |
| 2. shared `nidm/nidm.ttl` collision (#9) | fixed — per-subject layout, details below |
| 3. `-j` + `-n` footgun | confirmed absent, no change |
| 4. CI missing `submodules: recursive` | fixed |
| 5. no image-build job in CI | added docker-only build, on PRs as well as pushes |
| 6. `dataset_description.json` divergence | **no change needed** — see note below |

On item 6, the issue states freesurfer deliberately does not write this file. That is not what freesurfer does: `src/freesurfer/wrapper.py:404` writes one at the derivative root, and it simply never survives BABS zipping (only `sub-<id>/` is zipped). ANTs already matched that behaviour, so nothing changed.

## #9 — per-subject output layout

The output root is now the derivative root itself. Everything for a subject lives under `<output>/sub-<id>[/ses-<x>]/`:

```
sub-0051456/
├── anat/            dseg + per-label probseg maps
├── stats/           antslabelstats.csv, antsbrainvols.csv
├── nidm.ttl         input NIDM augmented with ANTs metrics
├── ants_cde.ttl     shared CDE vocabulary, alongside (never merged in)
└── processing_summary.json
```

No app-name wrapper, no shared `nidm/`, so the zip's top-level folder is the subject directory and two subjects cannot collide. Matches ReproNim/freesurfer-nidm_bidsapp#10 and the `fsl-nidm` app's delivered derivatives. Pairs with `zip_foldernames: {${subid}: "0-1-0"}` on the BABS side.

Verified end-to-end on a real BABS run: the delivered zip contains exactly one top-level subject directory with all five artifacts.

## Defects found by running it

None of these were in the issue. Each would have failed all 38 Caltech subjects.

1. **`find_nidm_input_file` never looked for `sub-<id>/nidm.ttl`** — the layout the shared NIDM datasets actually use (`nidm_4.5.0`). It fell through to a dataset-level `nidm.ttl` that does not exist there, so every subject would have been converted from scratch instead of augmenting its own record.
2. **`-session ses-<x>` passed to `ants_seg_to_nidm`, which has no such option** — argparse aborted every session-level run. Session identity is carried by the output directory instead.
3. **`--num-threads` had no effect.** ANTsPy takes no threads argument; ITK reads `ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS`, which both container recipes pin to 1. Joint label fusion registers 20 atlases, so this is the difference between a 1h23m job and one that never finishes.
4. **Missing `CSF Volume (mm^3)` common data element** (submodule). Label 24 is present in the joint-fusion atlas, so NIDM conversion raised `ValueError` for every subject.
5. **`prov[graph]` missing.** prov 3.0.0 moved NetworkX interop to an optional extra that `nidm.experiment` imports. The Jan container works only by the luck of having resolved prov 2.1.1; a fresh build gets prov 3.1.0 without networkx and `import ants_seg_to_nidm` dies outright.
6. **Brain mask warped the wrong way, so JLF labelled the whole head.** The most serious one — see below.

## The mask bug

The first real run (`sub-0051456`) completed in 1h23m with exit 0 and produced a well-formed NIDM file full of physically impossible numbers:

| measure | delivered | physiological |
|---|---|---|
| BVOL | 11,519,430 mm³ | 1.2–1.5 × 10⁶ |
| CSFVOL | 4,105 mm³ | ~1.5 × 10⁵ |
| GMVOL | 5,426 mm³ | ~6.0 × 10⁵ |
| WMVOL | 10,391 mm³ | ~5.0 × 10⁵ |

The segmentation explains it: **zero background voxels — 100% of the FOV labelled** — with label 4 (Left-Lateral-Ventricle) alone absorbing 69.6% of the image.

`compute_cortical_thickness` registers subject → template (`fixed=brain_template, moving=brain_image`), so `fwdtransforms` maps subject → template. It then pulled the template-space extraction mask into subject space using **`fwdtransforms`** — the wrong direction; that needs `invtransforms` ("Transforms to move from fixed to moving image"). `FillHoles` + `GetLargestComponent` then inflated the result to the full FOV, so `masked_brain` was the whole head and JLF's `target_image_mask` constrained nothing. The initial-mask call 40 lines earlier already used `invtransforms` correctly, so this was an internal inconsistency.

This also silently broke `--method quick`, which warps the label atlas with the same transforms and additionally hardcoded `whichtoinvert=False` for every element — wrong for the affine in an `invtransforms` list. Both paths now pass the ordered list through verbatim and let `apply_transforms` infer `whichtoinvert`. The two positional `TemplateToSubject*` keys are replaced by one ordered `TemplateToSubjectTransforms` list, removing the per-element bookkeeping that caused the bug.

A regression test covers the direction, and was verified to fail when the `fwdtransforms` version is put back.

## Two more the same run exposed

- **`CSFVOL`/`GMVOL`/`WMVOL` were never tissue volumes.** They came from `probabilityimages[0..2]` on the assumption those are CSF/GM/WM posteriors. Under `fusion` they are per-**label** posteriors (103 on this subject), so the numbers above are just the first three DKT labels wearing tissue names; under `quick` the key does not exist, so the branch never ran. That is every code path, so the columns are dropped. Real tissue volumes need DKT-label grouping or Atropos posteriors — separate work, and reporting nothing beats reporting numbers off by ~100×. Note `test_organize_bids_output_single_session` *asserted these columns existed*, i.e. a passing suite was protecting the bug; it now asserts their absence.
- **Probability maps were named by list position** (`label-1` … `label-104`) rather than by `segmentation_numbers`, so they could not be matched to the structures they describe.

## NIDM stack aligned with freesurfer

`requirements.txt` becomes the single source of truth: `pynidm==4.5.0` (the shared `nidm_4.5.0` inputs are produced with 4.5.0), `oxrdflib~=0.5.0`, `prov[graph]`, and a forced `rdflib>=7.0.0,<8`. Container recipes now install the submodule first and apply the top-level pins on top — the old order installed the submodule's `requirements.txt` last, so its `pynidm==4.2.4` silently overrode the app's pin. The Dockerfile also never `COPY`ed `requirements.txt`, so it could not have applied those pins at all.

Verified the converter against the real `nidm_4.5.0/sub-0051456/nidm.ttl` on both stacks — identical results, no regression from the bump:

| | pynidm 4.2.4 | pynidm 4.5.0 + rdflib 7.6.0 |
|---|---|---|
| output triples | 1131 | 1131 |
| ground input triples lost | 0 / 921 | 0 / 921 |
| measurements delivered | 102 | 102 |

## Submodule

`src/ants_seg_to_nidm` moves to `dfa02b8` (branch `simple2`): the CSF CDE fix, 9 further CDEs for `ctx-lh-frontalpole` / `ctx-lh-temporalpole` / `ctx-rh-frontalpole` found by re-auditing against the 20 *individual* atlas label files rather than the pre-computed template, a missing `import sys` that made `--collect-missing` die with `NameError`, and the dependency pins.

## Testing

19 tests pass. New coverage: transform direction (verified to catch the bug), per-subject NIDM discovery including the `sub-<id>/nidm.ttl` form, no cross-subject NIDM path collision, absence of `-session`, `processing_summary.json` landing inside the subject directory, probseg naming by label, and BIDSVersion shape.

## Still open, deliberately not in this PR

- Real tissue volumes for the `fusion` method.
- The app's own log is written to `<output>/logs/`, outside `sub-<id>/`, so BABS discards it. Only the scheduler's stdout/stderr survives.
- Resource sizing in the BABS config is provisional: the 33.5 GB MaxRSS / 1h23m measurements come from the run that segmented the whole head, so they need re-measuring against a correct run.
