### PR TITLE
Replace hand-rolled brain extraction with canonical antsBrainExtraction.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
         cmake \
         build-essential \
         libgomp1 \
+        bc \
         ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -30,6 +31,22 @@ RUN pip3 install --no-cache-dir \
     pybids \
     nipype \
     antspyx
+
+# Canonical ANTs binaries, pinned release. The wrapper shells out to
+# antsBrainExtraction.sh (the published extraction method the OASIS-30
+# template kit was built for); ANTsPy does not ship the CLI tools or the
+# scripts. The layout inside the release zip is not guaranteed, so locate
+# antsBrainExtraction.sh and symlink its directory to a fixed path.
+# Mirrors Singularity exactly and must stay in sync with it.
+RUN wget -q "https://github.com/ANTsX/ANTs/releases/download/v2.5.4/ants-2.5.4-ubuntu-22.04-X64-gcc.zip" -O /tmp/ants.zip && \
+    unzip -q /tmp/ants.zip -d /opt/ants-dist && \
+    rm /tmp/ants.zip && \
+    ABE="$(find /opt/ants-dist -type f -name antsBrainExtraction.sh | head -1)" && \
+    test -n "$ABE" && \
+    ln -s "$(dirname "$ABE")" /opt/ants-bin && \
+    chmod -R a+rx /opt/ants-dist && \
+    test -x /opt/ants-bin/antsRegistration && \
+    test -x /opt/ants-bin/Atropos
 
 # Create directory for templates with proper permissions
 RUN mkdir -p /opt/data && chmod 755 /opt/data
@@ -103,8 +120,9 @@ RUN pip3 install -e src/ants_seg_to_nidm && \
     chmod -R 755 /app
 
 # Set environment variables
-ENV ANTSPATH=/usr/local/bin
-ENV PATH=/usr/local/bin:$PATH
+# Trailing slash: older ANTs scripts concatenate ${ANTSPATH}tool directly
+ENV ANTSPATH=/opt/ants-bin/
+ENV PATH=/opt/ants-bin:/usr/local/bin:$PATH
 ENV ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
 
 # Create work directory for temporary files with world-writable permissions

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ singularity build ants-nidm_bidsapp.sif docker-daemon://ants-nidm_bidsapp:latest
 
 ## Usage
 
+### Quickstart (container, recommended)
+
+Build the container once (see above), then run one subject with the bundled
+wrapper — it sets up the binds and writable scratch the image expects:
+
+```bash
+./run_container.sh ants-nidm_bidsapp.sif /path/to/bids /path/to/output 01
+```
+
+The wrapper works with an Apptainer/Singularity `.sif` file or a Docker image
+name, and passes any extra arguments straight to the app:
+
+```bash
+./run_container.sh ants-nidm_bidsapp.sif /path/to/bids /path/to/output 01 \
+  --num-threads 8 --nidm-input-dir /path/to/nidm --verbose
+```
+
+Expect roughly 1–2 hours per subject at 8–16 threads and up to ~18 GB of RAM
+for the default joint-label-fusion method.
+
 ### Basic Usage
 
 ```bash

--- a/Singularity
+++ b/Singularity
@@ -20,6 +20,7 @@ From: ubuntu:22.04
         git \
         wget \
         unzip \
+        bc \
         && apt clean && \
         rm -rf /var/lib/apt/lists/*
 
@@ -38,6 +39,24 @@ From: ubuntu:22.04
     # Create application directories
     mkdir -p /opt/src
     mkdir -p /opt/data
+
+    # Canonical ANTs binaries, pinned release. The wrapper shells out to
+    # antsBrainExtraction.sh (the published extraction method the OASIS-30
+    # template kit was built for); ANTsPy does not ship the CLI tools or the
+    # scripts. The layout inside the release zip is not guaranteed, so locate
+    # antsBrainExtraction.sh and symlink its directory to a fixed path.
+    wget -q "https://github.com/ANTsX/ANTs/releases/download/v2.5.4/ants-2.5.4-ubuntu-22.04-X64-gcc.zip" -O /tmp/ants.zip
+    unzip -q /tmp/ants.zip -d /opt/ants-dist
+    rm /tmp/ants.zip
+    ABE="$(find /opt/ants-dist -type f -name antsBrainExtraction.sh | head -1)"
+    if [ -z "$ABE" ]; then
+        echo "ERROR: antsBrainExtraction.sh not found in ANTs release zip" >&2
+        exit 1
+    fi
+    ln -s "$(dirname "$ABE")" /opt/ants-bin
+    chmod -R a+rx /opt/ants-dist
+    test -x /opt/ants-bin/antsRegistration
+    test -x /opt/ants-bin/Atropos
 
     # Download and extract template files
     cd /opt/data
@@ -110,8 +129,9 @@ From: ubuntu:22.04
     # Add opt to Python path
     export PYTHONPATH=/opt:$PYTHONPATH
     # Add Python packages to path
-    export PATH=/usr/local/bin:$PATH
-    export ANTSPATH=/usr/local/bin
+    export PATH=/opt/ants-bin:/usr/local/bin:$PATH
+    # Trailing slash: older ANTs scripts concatenate ${ANTSPATH}tool directly
+    export ANTSPATH=/opt/ants-bin/
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export TMPDIR=/work
     export TEMP=/work

--- a/run_container.sh
+++ b/run_container.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Run the ants-nidm BIDS App container on a BIDS dataset.
+#
+# This wrapper exists because the container needs a handful of non-obvious
+# runtime arguments to work outside the cluster it was developed on:
+#   - a writable /work bind (the image sets TMPDIR=/work, which is read-only
+#     inside a SIF unless something writable is mounted over it)
+#   - read-only input / writable output binds with absolute paths
+#   - a sensible thread count passed through to the app
+#
+# Usage:
+#   ./run_container.sh <image> <bids_dir> <output_dir> <participant-label> [extra app args...]
+#
+#   <image>  path to ants-nidm_bidsapp.sif (Apptainer/Singularity), or a
+#            Docker image name such as ants-nidm_bidsapp:latest
+#
+# Examples:
+#   ./run_container.sh ants-nidm_bidsapp.sif  /data/bids /data/derivatives/ants-nidm 01
+#   ./run_container.sh ants-nidm_bidsapp:latest /data/bids /data/derivatives/ants-nidm 01 --num-threads 8 --verbose
+#
+# Anything after the participant label is passed to the app unchanged
+# (e.g. --session-label, --nidm-input-dir, --method quick, --num-threads N).
+
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+    grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed -n '2,24p'
+    exit 1
+fi
+
+IMAGE="$1"
+BIDS_DIR="$(cd "$2" && pwd)"
+OUTPUT_DIR="$3"
+PARTICIPANT="$4"
+shift 4
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ants-nidm-work.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Default to 4 threads unless the caller passes their own --num-threads
+THREAD_ARGS=()
+case " $* " in
+    *" --num-threads "*) ;;
+    *) THREAD_ARGS=(--num-threads 4) ;;
+esac
+
+if [ -f "$IMAGE" ]; then
+    # Apptainer / Singularity image file
+    RUNNER=""
+    command -v apptainer >/dev/null 2>&1 && RUNNER=apptainer
+    [ -z "$RUNNER" ] && command -v singularity >/dev/null 2>&1 && RUNNER=singularity
+    if [ -z "$RUNNER" ]; then
+        echo "ERROR: '$IMAGE' is a file but neither apptainer nor singularity is installed." >&2
+        exit 1
+    fi
+    exec "$RUNNER" run \
+        --userns --no-home \
+        -B "$BIDS_DIR":"$BIDS_DIR":ro \
+        -B "$OUTPUT_DIR":"$OUTPUT_DIR" \
+        -B "$WORK_DIR":/work \
+        "$IMAGE" \
+        "$BIDS_DIR" "$OUTPUT_DIR" participant \
+        --participant-label "$PARTICIPANT" \
+        "${THREAD_ARGS[@]}" "$@"
+else
+    # Docker image name
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "ERROR: '$IMAGE' is not a file and docker is not installed." >&2
+        exit 1
+    fi
+    exec docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v "$BIDS_DIR":"$BIDS_DIR":ro \
+        -v "$OUTPUT_DIR":"$OUTPUT_DIR" \
+        -v "$WORK_DIR":/work \
+        "$IMAGE" \
+        "$BIDS_DIR" "$OUTPUT_DIR" participant \
+        --participant-label "$PARTICIPANT" \
+        "${THREAD_ARGS[@]}" "$@"
+fi

--- a/src/antspy/wrapper.py
+++ b/src/antspy/wrapper.py
@@ -1,6 +1,8 @@
 # src/ants/wrapper.py
 import os
+import shutil
 import subprocess
+import tempfile
 import logging
 import importlib
 import ants
@@ -743,50 +745,61 @@ class ANTsSegmentation:
             spline_param=200
         )
         
-        # Initial brain extraction, antsBrainExtraction.sh semantics: register
-        # the whole-head subject to the whole-head T_template0 with the
-        # ExtractionMask restricting the metric region (that is what that
-        # 5.9 L mask is for), then pull the brain probability mask into
-        # subject space. The previous init registered whole-head onto the
-        # brain-only BrainCerebellum template, rigid-only and unmasked --
-        # content-mismatched and without scaling, which turned out bistable
-        # across CPU types: identical code and input gave a 1.70 L final mask
-        # on node1406, 2.84 L on node2906 and 3.25 L on node2000. Affine (so
-        # head size lands in the transform, not the mask) plus matched content
-        # plus the metric mask keeps every node in the same basin.
-        self.logger.info("Performing initial brain extraction")
-        head_template = ants.image_read(str(self.template_dir / 'T_template0.nii.gz'))
+        # Brain extraction: run the canonical antsBrainExtraction.sh, the
+        # published method the OASIS-30 template kit was built for, with each
+        # template file in its designed role (-e whole-head template, -m brain
+        # probability mask, -f extraction registration-scope mask). Two
+        # successive hand-rolled re-implementations each fixed one failure
+        # mode and left another (whole-head masks, CPU-type bistability, and
+        # finally 11/33 ABIDE Caltech subjects at 2.05-3.87 L on hard
+        # anatomies): the script's SyN stage and Atropos K=3 refinement are
+        # what adapt the mask to each subject, and they are not worth
+        # re-deriving in ANTsPy piece by piece.
+        self.logger.info("Performing brain extraction (antsBrainExtraction.sh)")
+        abe_script = shutil.which('antsBrainExtraction.sh')
+        if not abe_script:
+            raise RuntimeError(
+                "antsBrainExtraction.sh not found on PATH. The container must "
+                "ship the ANTs binaries (see Singularity/Dockerfile); ANTsPy "
+                "alone does not include them.")
+
+        abe_dir = Path(tempfile.mkdtemp(prefix='abe_', dir=str(self.temp_dir) if self.temp_dir else None))
+        try:
+            abe_input = abe_dir / 'n4.nii.gz'
+            ants.image_write(n4_image, str(abe_input))
+            abe_prefix = str(abe_dir / 'abe_')
+            cmd = [
+                abe_script,
+                '-d', '3',
+                '-a', str(abe_input),
+                '-e', str(self.template_dir / 'T_template0.nii.gz'),
+                '-m', str(self.template_dir / 'T_template0_BrainCerebellumProbabilityMask.nii.gz'),
+                '-f', str(self.template_dir / 'T_template0_BrainCerebellumExtractionMask.nii.gz'),
+                '-o', abe_prefix,
+            ]
+            self.logger.info(f"Running: {' '.join(cmd)}")
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            mask_path = Path(abe_prefix + 'BrainExtractionMask.nii.gz')
+            # The script can fail and still exit 0 (observed: missing `bc`
+            # printed a complaint to stdout and returned success), so the
+            # only trustworthy success signal is the output mask existing.
+            if proc.returncode != 0 or not mask_path.exists():
+                self.logger.error(f"antsBrainExtraction.sh stdout:\n{proc.stdout}")
+                self.logger.error(f"antsBrainExtraction.sh stderr:\n{proc.stderr}")
+                raise RuntimeError(
+                    f"antsBrainExtraction.sh failed (exit code {proc.returncode}, "
+                    f"mask present: {mask_path.exists()}). "
+                    f"stdout: {proc.stdout[-2000:]} stderr: {proc.stderr[-2000:]}")
+
+            final_mask = ants.image_read(str(mask_path))
+        finally:
+            # The extracted-brain intermediate is large; keep only what was
+            # read back into memory.
+            shutil.rmtree(abe_dir, ignore_errors=True)
+
+        brain_image = n4_image * final_mask
+
         reg_template = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellum.nii.gz'))
-        prob_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumProbabilityMask.nii.gz'))
-        extraction_mask = ants.image_read(str(self.template_dir / 'T_template0_BrainCerebellumExtractionMask.nii.gz'))
-
-        # Initial affine registration, metric restricted to the head region
-        init_reg = ants.registration(
-            fixed=head_template,
-            moving=n4_image,
-            type_of_transform='Affine',
-            mask=extraction_mask,
-            aff_metric='mattes',
-            aff_sampling=32,
-            aff_random_sampling_rate=0.2,
-            reg_iterations=[1000, 500, 250],
-            verbose=True,
-            random_seed=1
-        )
-
-        # Transform probability mask to subject space
-        init_mask = ants.apply_transforms(
-            fixed=n4_image,
-            moving=prob_mask,
-            transformlist=init_reg['invtransforms'],
-            interpolator='linear'
-        )
-        
-        # Create brain mask and extract brain
-        brain_mask = ants.threshold_image(init_mask, 0.5, 1.0)
-        brain_mask = ants.iMath(brain_mask, "FillHoles")
-        brain_mask = ants.iMath(brain_mask, "GetLargestComponent")
-        brain_image = n4_image * brain_mask
         
         # Register to the brain-only template. brain_image is skull-stripped at
         # this point, so the fixed image must be skull-stripped too
@@ -842,31 +855,9 @@ class ANTsSegmentation:
             self.logger.info("Using affine registration only")
             transforms = list(affine_reg['invtransforms'])
 
-        # Build the final brain mask from the warped *ProbabilityMask*, exactly
-        # as in the initial-extraction step above but through the refined
-        # affine+SyN transforms. NOT the ExtractionMask: in the OASIS-30 kit
-        # that file is the generous registration-scope mask (5.9 L in template
-        # space, antsBrainExtraction.sh's -f argument), not a brain mask --
-        # using it here delivered a 5.6 L "brain" on ABIDE sub-0051456 even
-        # with the transform direction fixed. The probability mask thresholded
-        # at 0.5 is 1.34 L, matching the brain-only template.
-        # whichtoinvert is deliberately left unset: apply_transforms auto-detects
-        # the (True, False) pattern for the [affine.mat, InverseWarp] shape that
-        # invtransforms returns. Hand-maintaining that bookkeeping per element is
-        # what went wrong before, so it is not reintroduced here.
-        final_mask = ants.apply_transforms(
-            fixed=n4_image,
-            moving=prob_mask,
-            transformlist=transforms,
-            interpolator='linear'
-        )
-
-        # Ensure final mask is binary
-        final_mask = ants.threshold_image(final_mask, 0.5, 1.0)
-        final_mask = ants.iMath(final_mask, "FillHoles")
-        final_mask = ants.iMath(final_mask, "GetLargestComponent")
-        
-        # Prepare results dictionary
+        # Prepare results dictionary. BrainExtractionMask is the canonical
+        # script's product, untouched: its Atropos refinement and morphology
+        # already finalized it.
         results = {
             'BrainSegmentationN4': n4_image,
             'BrainExtractionMask': final_mask

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -194,61 +194,31 @@ class TestANTsSegmentation(unittest.TestCase):
                     any(f"label-{label_id}_probseg" in w for w in written),
                     f"no probseg written for label {label_id}: {written}")
 
-    def test_cortical_thickness_uses_invtransforms_for_template_to_subject(self):
-        """The final brain mask must come template -> subject, i.e. invtransforms.
+    def test_cortical_thickness_keeps_invtransforms_for_template_to_subject(self):
+        """TemplateToSubjectTransforms must be invtransforms of subject->template.
 
         Regression test. compute_cortical_thickness registers subject -> template
         (fixed=brain_template, moving=brain_image), so fwdtransforms maps
-        subject -> template. Pulling the template-space brain mask into
-        subject space with fwdtransforms produced a mask covering the whole FOV,
-        so joint label fusion labelled air, skull and neck -- 100% of voxels
-        labelled, no background, and an 11.5 L brain volume on ABIDE sub-0051456.
+        subject -> template. The 'quick' method pulls the template-space label
+        atlas into subject space with these transforms; using fwdtransforms
+        warped everything the wrong way (the original 11.5 L whole-FOV bug on
+        ABIDE sub-0051456).
         """
-        FWD = ["/fake/subj_to_tmpl_1Warp.nii.gz", "/fake/subj_to_tmpl_0GenericAffine.mat"]
-        INV = ["/fake/subj_to_tmpl_0GenericAffine.mat", "/fake/subj_to_tmpl_1InverseWarp.nii.gz"]
+        registrations, applied, subprocesses, results = \
+            self._run_cortical_thickness_recording_calls()
 
-        def fake_registration(*args, **kwargs):
-            return {
-                "fwdtransforms": list(FWD),
-                "invtransforms": list(INV),
-                "warpedmovout": mock_image_read(),
-            }
-
-        applied = []
-
-        def fake_apply_transforms(*args, **kwargs):
-            applied.append(kwargs)
-            return mock_image_read()
-
-        # Patch the name the module under test resolves, not this file's mock
-        # object: tests/test_run.py also assigns sys.modules['ants'], so which
-        # mock src.antspy.wrapper.ants points at depends on import order.
-        with patch('src.antspy.wrapper.ants.registration', side_effect=fake_registration), \
-             patch('src.antspy.wrapper.ants.apply_transforms', side_effect=fake_apply_transforms), \
-             patch('src.antspy.wrapper.ants.threshold_image', side_effect=lambda *a, **k: mock_image_read()), \
-             patch('src.antspy.wrapper.ants.iMath', side_effect=lambda img, *a, **k: img):
-            results = self.segmenter.compute_cortical_thickness(mock_image_read())
-
-        # Last apply_transforms call is the extraction mask -> subject space
-        self.assertGreaterEqual(len(applied), 1)
-        mask_call = applied[-1]
-        self.assertEqual(
-            mask_call["transformlist"], INV,
-            "extraction mask must be warped with invtransforms (template -> subject)")
-        self.assertNotEqual(
-            mask_call["transformlist"], FWD,
-            "using fwdtransforms warps the mask the wrong way and yields a full-FOV mask")
-        # whichtoinvert must stay unset so ANTsPy infers (True, False) itself
-        self.assertIsNone(mask_call.get("whichtoinvert"))
-
-        # The stored template->subject transforms are the same ordered list
-        self.assertEqual(results["TemplateToSubjectTransforms"], INV)
+        INV = ["/fake/0GenericAffine.mat", "/fake/1InverseWarp.nii.gz"]
+        FWD = ["/fake/1Warp.nii.gz", "/fake/0GenericAffine.mat"]
+        self.assertEqual(results["TemplateToSubjectTransforms"], INV,
+                         "template->subject direction requires invtransforms")
+        self.assertNotEqual(results["TemplateToSubjectTransforms"], FWD)
 
     def _run_cortical_thickness_recording_calls(self):
         """Run compute_cortical_thickness with mocks that tag every image read
-        with its source path and record all registration/apply_transforms calls.
+        with its source path and record registration/apply_transforms calls
+        and the antsBrainExtraction.sh subprocess invocation.
 
-        Returns (registrations, applied, results).
+        Returns (registrations, applied, subprocesses, results).
         """
         def fake_image_read(path, *args, **kwargs):
             img = mock_image_read()
@@ -275,89 +245,107 @@ class TestANTsSegmentation(unittest.TestCase):
             out.src_path = getattr(moving, "src_path", None)
             return out
 
-        def fake_imath(img, *args, **kwargs):
-            return img
+        subprocesses = []
 
-        def fake_threshold(img, *args, **kwargs):
-            out = mock_image_read()
-            out.src_path = getattr(img, "src_path", None)
-            return out
+        def fake_subprocess_run(cmd, *args, **kwargs):
+            cmd = [str(c) for c in cmd]
+            subprocesses.append(cmd)
+            # Honour the script's contract: create the output mask the wrapper
+            # will check for, next to the -o prefix.
+            if any("antsBrainExtraction" in c for c in cmd) and "-o" in cmd:
+                prefix = cmd[cmd.index("-o") + 1]
+                Path(prefix + "BrainExtractionMask.nii.gz").touch()
+            return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch('src.antspy.wrapper.ants.image_read', side_effect=fake_image_read), \
+             patch('src.antspy.wrapper.ants.image_write', side_effect=lambda img, path: None), \
              patch('src.antspy.wrapper.ants.n4_bias_field_correction', side_effect=lambda img, **k: mock_image_read()), \
              patch('src.antspy.wrapper.ants.registration', side_effect=fake_registration), \
              patch('src.antspy.wrapper.ants.apply_transforms', side_effect=fake_apply_transforms), \
-             patch('src.antspy.wrapper.ants.threshold_image', side_effect=fake_threshold), \
-             patch('src.antspy.wrapper.ants.iMath', side_effect=fake_imath):
+             patch('src.antspy.wrapper.ants.threshold_image', side_effect=lambda img, *a, **k: img), \
+             patch('src.antspy.wrapper.ants.iMath', side_effect=lambda img, *a, **k: img), \
+             patch('src.antspy.wrapper.subprocess.run', side_effect=fake_subprocess_run), \
+             patch('src.antspy.wrapper.shutil.which', return_value='/opt/ants/bin/antsBrainExtraction.sh'):
             results = self.segmenter.compute_cortical_thickness(mock_image_read())
 
-        return registrations, applied, results
+        return registrations, applied, subprocesses, results
 
-    def test_final_brain_mask_derived_from_probability_mask(self):
-        """The final brain mask must come from the brain probability mask.
+    def test_brain_extraction_runs_canonical_ants_script(self):
+        """Brain extraction must be antsBrainExtraction.sh, not a hand-rolled copy.
 
-        Regression test. T_template0_BrainCerebellumExtractionMask is the
-        generous registration-scope mask of the OASIS-30 kit (5.9 L in template
-        space -- antsBrainExtraction.sh's -f argument), not a brain mask. Using
-        it as the final mask labelled ~5.6 L of head on ABIDE sub-0051456. The
-        brain mask is the warped ProbabilityMask thresholded at 0.5 (1.34 L).
+        Regression test. Two successive re-implementations of the extraction
+        (fix 4f57540, then 3f51754) each fixed one failure mode and left
+        another: the aug28 production run still delivered 11/33 subjects with
+        2.05-3.87 L masks on hard anatomies, because the hand-rolled pipeline
+        lacks the script's SyN stage and Atropos K=3 refinement. The canonical
+        script is the published method the OASIS-30 template kit was built
+        for, with each template file in its designed role:
+          -e whole-head template, -m brain probability mask,
+          -f extraction (registration-scope) mask.
         """
-        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+        registrations, applied, subprocesses, results = \
+            self._run_cortical_thickness_recording_calls()
 
-        self.assertGreaterEqual(len(applied), 2)
-        final_mask_src = applied[-1]["moving"].src_path
-        self.assertIn(
-            "ProbabilityMask", final_mask_src,
-            f"final brain mask must be warped from the ProbabilityMask, got {final_mask_src}")
-        self.assertNotIn(
-            "ExtractionMask", final_mask_src,
-            "ExtractionMask is a registration-scope mask (5.9 L), not a brain mask")
-        self.assertIn(
-            "ProbabilityMask", results["BrainExtractionMask"].src_path,
-            "returned BrainExtractionMask must trace back to the ProbabilityMask")
+        abe = [c for c in subprocesses if any("antsBrainExtraction" in a for a in c)]
+        self.assertEqual(len(abe), 1, f"expected one antsBrainExtraction.sh call, got {subprocesses}")
+        cmd = abe[0]
 
-    def test_initial_registration_is_head_to_head_with_extraction_metric_mask(self):
-        """The initial registration must match like content with like.
+        def arg_of(flag):
+            self.assertIn(flag, cmd, f"missing {flag} in {cmd}")
+            return cmd[cmd.index(flag) + 1]
 
-        Regression test. The old init registered the whole-head subject image
-        onto the brain-only BrainCerebellum template with a rigid-only
-        transform and no metric mask. That problem is bistable across CPU
-        types: identical code and input produced a 1.70 L mask on node1406,
-        2.84 L on node2906 and 3.25 L on node2000. Canonical
-        antsBrainExtraction.sh semantics instead: register whole-head to the
-        whole-head T_template0, restrict the metric with the ExtractionMask
-        (that file's actual job), and use an affine so head size differences
-        are absorbed by scaling, not by the mask.
+        self.assertEqual(arg_of("-d"), "3")
+        self.assertTrue(arg_of("-e").endswith("T_template0.nii.gz"),
+                        "-e must be the whole-head template")
+        self.assertIn("ProbabilityMask", arg_of("-m"),
+                      "-m must be the brain probability mask")
+        self.assertIn("ExtractionMask", arg_of("-f"),
+                      "-f must be the extraction registration mask")
+
+        # The returned mask must be the script's output product
+        self.assertIn("BrainExtractionMask.nii.gz",
+                      results["BrainExtractionMask"].src_path,
+                      "BrainExtractionMask must be read back from the script's output")
+
+    def test_brain_extraction_raises_when_script_produces_no_mask(self):
+        """A silent antsBrainExtraction.sh failure must become a loud error.
+
+        Regression test. The script can fail and still exit 0 -- observed with
+        a missing `bc` dependency: it printed "we cant find the bc program"
+        to stdout, produced nothing, and returned success, so the failure only
+        surfaced later as an unrelated file-not-found from image_read. The
+        wrapper must verify the output mask exists and raise a RuntimeError
+        carrying the script's own output.
         """
-        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+        def fake_subprocess_run(cmd, *args, **kwargs):
+            # Exit 0 but produce no output file
+            return MagicMock(returncode=0,
+                             stdout="we cant find the bc program", stderr="")
 
-        self.assertGreaterEqual(len(registrations), 2)
-        init = registrations[0]
-        fixed_src = init["fixed"].src_path
-        self.assertTrue(
-            fixed_src.endswith("T_template0.nii.gz"),
-            f"init registration must target the whole-head template, got {fixed_src}")
-        self.assertIn(
-            "Affine", init.get("type_of_transform", ""),
-            "init registration needs scaling (affine), rigid cannot absorb head size")
-        mask = init.get("mask")
-        self.assertIsNotNone(mask, "init registration must restrict its metric with a mask")
-        self.assertIn(
-            "ExtractionMask", mask.src_path,
-            f"the metric mask must be the ExtractionMask, got {mask.src_path}")
+        with patch('src.antspy.wrapper.ants.image_write', side_effect=lambda img, path: None), \
+             patch('src.antspy.wrapper.ants.n4_bias_field_correction', side_effect=lambda img, **k: mock_image_read()), \
+             patch('src.antspy.wrapper.subprocess.run', side_effect=fake_subprocess_run), \
+             patch('src.antspy.wrapper.shutil.which', return_value='/opt/ants/bin/antsBrainExtraction.sh'):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.segmenter.compute_cortical_thickness(mock_image_read())
+
+        self.assertIn("bc program", str(ctx.exception),
+                      "the script's own output must be in the error message")
 
     def test_refinement_registrations_target_brain_only_template(self):
-        """Affine/SyN refinement must target the brain-only template.
+        """Subject->template registrations must target the brain-only template.
 
-        The subject image is skull-stripped before these registrations, so the
-        fixed image must be T_template0_BrainCerebellum. Registering a
-        brain-only image onto the whole-head T_template0 biases the affine to
-        scale the brain toward the head outline, inflating the warped mask.
+        These run on the skull-stripped image (to produce the template-to-
+        subject transforms the 'quick' method needs), so the fixed image must
+        be T_template0_BrainCerebellum. Registering a brain-only image onto
+        the whole-head T_template0 biases the affine to scale the brain
+        toward the head outline.
         """
-        registrations, applied, results = self._run_cortical_thickness_recording_calls()
+        registrations, applied, subprocesses, results = \
+            self._run_cortical_thickness_recording_calls()
 
-        self.assertGreaterEqual(len(registrations), 3)
-        for i, reg in enumerate(registrations[1:], start=1):
+        self.assertGreaterEqual(len(registrations), 2)
+        for i, reg in enumerate(registrations):
             fixed_src = reg["fixed"].src_path
             self.assertIn(
                 "BrainCerebellum", fixed_src,


### PR DESCRIPTION
## Why

After #11, the first full 38-subject ABIDE Caltech run still delivered 11/33 subjects with implausible brain masks (2.05–3.87 L) on hard anatomies. The hand-rolled extraction lacked the canonical script's SyN stage and Atropos K=3 refinement — the parts that adapt the mask to each subject. Re-deriving them piecewise in ANTsPy is exactly how the previous two extraction bugs happened, so this PR stops approximating the published method and runs it.

## What

- `compute_cortical_thickness` shells out to **`antsBrainExtraction.sh`** with each OASIS-30 template file in its designed role (`-e` whole-head template, `-m` brain probability mask, `-f` extraction registration mask) and uses its `BrainExtractionMask` as-is. The subject→template affine+SyN registration is kept to supply the `quick` method's transforms.
- The script can fail and still **exit 0** (observed with missing `bc`: complaint on stdout, exit 0, no output) — the wrapper now treats the mask file's existence as the only success signal and raises with the script's own output otherwise. Regression-tested.
- Both containers ship pinned **ANTs 2.5.4** release binaries plus `bc`, Dockerfile and Singularity in sync.
- New `run_container.sh` + README quickstart so external researchers can run one subject with a single command (writable `/work` bind and friends encoded once).

## Verification

Mask volumes on the three worst previous failures (old → new):

| Subject | old | new | reference |
|---|---|---|---|
| sub-0051464 | 3.87 L | 2.083 L | FreeSurfer BrainSegVol 1.98 L / eTIV 2.17 L — new mask is anatomically correct |
| sub-0051457 | 3.42 L | 1.715 L | |
| sub-0051467 | 3.14 L | 1.743 L | |

Full 38-subject rerun with this container is in progress; unit suite 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)